### PR TITLE
Messaging - General

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,17 +73,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -466,256 +455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "asset-hub-paseo-runtime"
-version = "1.0.0"
-source = "git+https://github.com/paseo-network/runtimes?tag=v1.3.4#313b81aa2b2cb076b4f99c9b2bea040a8bcf709f"
-dependencies = [
- "assets-common 0.15.0",
- "bp-asset-hub-paseo",
- "bp-bridge-hub-kusama",
- "bp-bridge-hub-paseo",
- "bp-bridge-hub-polkadot",
- "collectives-polkadot-runtime-constants",
- "cumulus-pallet-aura-ext 0.15.0",
- "cumulus-pallet-parachain-system 0.15.0",
- "cumulus-pallet-session-benchmarking 17.0.0",
- "cumulus-pallet-xcm 0.15.0",
- "cumulus-pallet-xcmp-queue 0.15.0",
- "cumulus-primitives-aura 0.14.0",
- "cumulus-primitives-core 0.14.0",
- "cumulus-primitives-utility 0.15.0",
- "frame-benchmarking 36.0.0",
- "frame-executive 36.0.0",
- "frame-metadata-hash-extension 0.4.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "frame-system-benchmarking 36.0.0",
- "frame-system-rpc-runtime-api 33.0.0",
- "frame-try-runtime 0.42.0",
- "hex-literal",
- "log",
- "pallet-asset-conversion 18.0.0",
- "pallet-asset-conversion-tx-payment 18.0.0",
- "pallet-assets 37.0.0",
- "pallet-aura 35.0.0",
- "pallet-authorship 36.0.0",
- "pallet-balances 37.0.0",
- "pallet-collator-selection 17.0.0",
- "pallet-message-queue 39.0.2",
- "pallet-multisig 36.0.0",
- "pallet-nfts 30.0.0",
- "pallet-nfts-runtime-api 22.0.0",
- "pallet-proxy 36.0.0",
- "pallet-session 36.0.0",
- "pallet-sudo 36.0.0",
- "pallet-timestamp 35.0.0",
- "pallet-transaction-payment 36.0.0",
- "pallet-transaction-payment-rpc-runtime-api 36.0.0",
- "pallet-uniques 36.0.0",
- "pallet-utility 36.0.0",
- "pallet-vesting 36.0.0",
- "pallet-xcm 15.0.0",
- "pallet-xcm-benchmarks 15.0.0",
- "pallet-xcm-bridge-hub-router 0.13.0",
- "parachains-common 15.0.0",
- "parity-scale-codec",
- "paseo-runtime-constants",
- "polkadot-core-primitives 14.0.0",
- "polkadot-parachain-primitives 13.0.0",
- "polkadot-runtime-common 15.0.0",
- "primitive-types 0.12.2",
- "scale-info",
- "serde_json",
- "snowbridge-router-primitives 0.14.0",
- "sp-api 33.0.0",
- "sp-block-builder 33.0.0",
- "sp-consensus-aura 0.39.0",
- "sp-core 34.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-genesis-builder 0.14.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-offchain 33.0.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 21.0.0",
- "sp-transaction-pool 33.0.0",
- "sp-version 36.0.0",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-parachain-info 0.15.0",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
- "system-parachains-constants 1.0.0 (git+https://github.com/paseo-network/runtimes?tag=v1.3.4)",
- "xcm-runtime-apis 0.2.0",
-]
-
-[[package]]
-name = "asset-hub-westend-runtime"
-version = "0.27.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "assets-common 0.19.0",
- "bp-asset-hub-rococo",
- "bp-asset-hub-westend",
- "bp-bridge-hub-rococo",
- "bp-bridge-hub-westend",
- "cumulus-pallet-aura-ext 0.18.0",
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-session-benchmarking 20.0.0",
- "cumulus-pallet-xcm 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-aura 0.16.0",
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-storage-weight-reclaim",
- "cumulus-primitives-utility 0.18.0",
- "frame-benchmarking 39.0.0",
- "frame-executive 39.0.0",
- "frame-metadata-hash-extension 0.7.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-system-benchmarking 39.0.0",
- "frame-system-rpc-runtime-api 35.0.0",
- "frame-try-runtime 0.45.0",
- "hex-literal",
- "log",
- "pallet-asset-conversion 21.0.0",
- "pallet-asset-conversion-ops",
- "pallet-asset-conversion-tx-payment 21.0.0",
- "pallet-assets 41.0.0",
- "pallet-assets-freezer",
- "pallet-aura 38.0.0",
- "pallet-authorship 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-collator-selection 20.0.0",
- "pallet-message-queue 42.0.0",
- "pallet-multisig 39.0.0",
- "pallet-nft-fractionalization",
- "pallet-nfts 33.0.0",
- "pallet-nfts-runtime-api 25.0.0",
- "pallet-proxy 39.0.0",
- "pallet-revive",
- "pallet-session 39.0.0",
- "pallet-state-trie-migration 43.0.0",
- "pallet-timestamp 38.0.0",
- "pallet-transaction-payment 39.0.0",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
- "pallet-uniques 39.0.0",
- "pallet-utility 39.0.0",
- "pallet-xcm 18.0.0",
- "pallet-xcm-benchmarks 18.0.0",
- "pallet-xcm-bridge-hub-router 0.16.0",
- "parachains-common 19.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-runtime-common 18.0.0",
- "primitive-types 0.13.1",
- "scale-info",
- "serde_json",
- "snowbridge-router-primitives 0.18.1",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
- "sp-consensus-aura 0.41.0",
- "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
- "sp-keyring 40.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-storage 22.0.0",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
- "staging-parachain-info 0.18.0",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
- "testnet-parachains-constants",
- "westend-runtime-constants",
- "xcm-runtime-apis 0.5.0",
-]
-
-[[package]]
-name = "asset-test-utils"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-assets 41.0.0",
- "pallet-balances 40.0.0",
- "pallet-collator-selection 20.0.0",
- "pallet-session 39.0.0",
- "pallet-timestamp 38.0.0",
- "pallet-xcm 18.0.0",
- "pallet-xcm-bridge-hub-router 0.16.0",
- "parachains-common 19.0.0",
- "parachains-runtimes-test-utils",
- "parity-scale-codec",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "staging-parachain-info 0.18.0",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
-]
-
-[[package]]
-name = "assets-common"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e2360c96927aa33b3fef7190eabf2aa4129fe3505c11dfa860ada0f27fd1b1"
-dependencies = [
- "cumulus-primitives-core 0.14.0",
- "frame-support 36.0.1",
- "impl-trait-for-tuples",
- "log",
- "pallet-asset-conversion 18.0.0",
- "pallet-xcm 15.0.0",
- "parachains-common 15.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
-]
-
-[[package]]
-name = "assets-common"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-asset-conversion 21.0.0",
- "pallet-assets 41.0.0",
- "pallet-xcm 18.0.0",
- "parachains-common 19.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,16 +775,6 @@ dependencies = [
 
 [[package]]
 name = "binary-merkle-tree"
-version = "15.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336bf780dd7526a9a4bc1521720b25c1994dc132cccd59553431923fa4d1a693"
-dependencies = [
- "hash-db",
- "log",
-]
-
-[[package]]
-name = "binary-merkle-tree"
 version = "16.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
@@ -1316,364 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bp-asset-hub-paseo"
-version = "1.0.0"
-source = "git+https://github.com/paseo-network/runtimes?tag=v1.3.4#313b81aa2b2cb076b4f99c9b2bea040a8bcf709f"
-dependencies = [
- "bp-xcm-bridge-hub-router 0.13.0",
- "frame-support 36.0.1",
- "parity-scale-codec",
- "scale-info",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "system-parachains-constants 1.0.0 (git+https://github.com/paseo-network/runtimes?tag=v1.3.4)",
-]
-
-[[package]]
-name = "bp-asset-hub-rococo"
-version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-xcm-bridge-hub-router 0.15.0",
- "frame-support 39.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 35.0.0",
- "staging-xcm 15.0.1",
-]
-
-[[package]]
-name = "bp-asset-hub-westend"
-version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-xcm-bridge-hub-router 0.15.0",
- "frame-support 39.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 35.0.0",
- "staging-xcm 15.0.1",
-]
-
-[[package]]
-name = "bp-bridge-hub-cumulus"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cca10dce1c6d2914e48594f13add2da4a5b7c3ed54fd0fa324054dfb8569a"
-dependencies = [
- "bp-messages 0.15.0",
- "bp-polkadot-core 0.15.0",
- "bp-runtime 0.15.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "polkadot-primitives 14.0.0",
- "sp-api 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bp-bridge-hub-cumulus"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-messages 0.19.0",
- "bp-polkadot-core 0.19.0",
- "bp-runtime 0.19.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "polkadot-primitives 17.0.0",
- "sp-api 35.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "bp-bridge-hub-kusama"
-version = "1.0.0"
-source = "git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4#3b18d942c766c7f358da50608b44edbe218284a4"
-dependencies = [
- "bp-bridge-hub-cumulus 0.15.0",
- "bp-messages 0.15.0",
- "bp-runtime 0.15.0",
- "frame-support 36.0.1",
- "kusama-runtime-constants",
- "polkadot-runtime-constants",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "system-parachains-constants 1.0.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4)",
-]
-
-[[package]]
-name = "bp-bridge-hub-paseo"
-version = "1.0.0"
-source = "git+https://github.com/paseo-network/runtimes?tag=v1.3.4#313b81aa2b2cb076b4f99c9b2bea040a8bcf709f"
-dependencies = [
- "bp-bridge-hub-cumulus 0.15.0",
- "bp-messages 0.15.0",
- "bp-polkadot-bulletin",
- "bp-runtime 0.15.0",
- "frame-support 36.0.1",
- "kusama-runtime-constants",
- "paseo-runtime-constants",
- "snowbridge-core 0.8.0",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "system-parachains-constants 1.0.0 (git+https://github.com/paseo-network/runtimes?tag=v1.3.4)",
-]
-
-[[package]]
-name = "bp-bridge-hub-polkadot"
-version = "1.0.0"
-source = "git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4#3b18d942c766c7f358da50608b44edbe218284a4"
-dependencies = [
- "bp-bridge-hub-cumulus 0.15.0",
- "bp-messages 0.15.0",
- "bp-polkadot-bulletin",
- "bp-runtime 0.15.0",
- "frame-support 36.0.1",
- "kusama-runtime-constants",
- "polkadot-runtime-constants",
- "snowbridge-core 0.8.0",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "system-parachains-constants 1.0.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4)",
-]
-
-[[package]]
-name = "bp-bridge-hub-rococo"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-bridge-hub-cumulus 0.19.0",
- "bp-messages 0.19.0",
- "bp-runtime 0.19.0",
- "bp-xcm-bridge-hub",
- "frame-support 39.0.0",
- "parity-scale-codec",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "bp-bridge-hub-westend"
-version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-bridge-hub-cumulus 0.19.0",
- "bp-messages 0.19.0",
- "bp-runtime 0.19.0",
- "bp-xcm-bridge-hub",
- "frame-support 39.0.0",
- "parity-scale-codec",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "bp-header-chain"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cac4b71008e46d43e346476ed1be85cf7b505efacee17dad84d687344bf1b1"
-dependencies = [
- "bp-runtime 0.15.0",
- "finality-grandpa",
- "frame-support 36.0.1",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-consensus-grandpa 20.0.0",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bp-header-chain"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-runtime 0.19.0",
- "finality-grandpa",
- "frame-support 39.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-consensus-grandpa 22.0.0",
- "sp-core 35.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "bp-messages"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97eec00a98efeb052ac9fc9676d9fccf5acd19e3b18530f3d72af1a1faf21ec"
-dependencies = [
- "bp-header-chain 0.15.0",
- "bp-runtime 0.15.0",
- "frame-support 36.0.1",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bp-messages"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-header-chain 0.19.0",
- "bp-runtime 0.19.0",
- "frame-support 39.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "bp-polkadot-bulletin"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb5b3cd885b40b52bf96e52ffbec92d0c435f7303fc11374ccfcfa5bebfbc4f"
-dependencies = [
- "bp-header-chain 0.15.0",
- "bp-messages 0.15.0",
- "bp-polkadot-core 0.15.0",
- "bp-runtime 0.15.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bp-polkadot-core"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef2272823ecfee580c00f6542dfcab3ec7abdb00857af853429736847c3a2d9"
-dependencies = [
- "bp-messages 0.15.0",
- "bp-runtime 0.15.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "parity-util-mem",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bp-polkadot-core"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-messages 0.19.0",
- "bp-runtime 0.19.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 35.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "bp-runtime"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904644c23b437dde65741f3148067624ed0b4d8360f68adf9e92273aeb970814"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "hash-db",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
- "trie-db",
-]
-
-[[package]]
-name = "bp-runtime"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "hash-db",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-state-machine 0.44.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-trie 38.0.0",
- "trie-db",
-]
-
-[[package]]
-name = "bp-xcm-bridge-hub"
-version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-messages 0.19.0",
- "bp-runtime 0.19.0",
- "frame-support 39.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-xcm 15.0.1",
-]
-
-[[package]]
-name = "bp-xcm-bridge-hub-router"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7dae4d1ec894ee920195dd39070b279ef3c1d4d078c3fcf7336c93a1d502a9d"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
-]
-
-[[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.15.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
@@ -1681,7 +1052,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "staging-xcm 15.0.1",
 ]
 
@@ -2027,11 +1398,6 @@ dependencies = [
  "termcolor",
  "unicode-width 0.1.14",
 ]
-
-[[package]]
-name = "collectives-polkadot-runtime-constants"
-version = "1.0.0"
-source = "git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4#3b18d942c766c7f358da50608b44edbe218284a4"
 
 [[package]]
 name = "color-print"
@@ -2557,7 +1923,7 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "url",
 ]
 
@@ -2568,19 +1934,19 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-client-api",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -2594,8 +1960,8 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-proposer",
  "cumulus-client-parachain-inherent",
- "cumulus-primitives-aura 0.16.0",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "futures",
  "parity-scale-codec",
@@ -2604,7 +1970,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-aura",
@@ -2613,18 +1979,18 @@ dependencies = [
  "sc-telemetry",
  "sc-utils",
  "schnellru",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.41.0",
+ "sp-consensus-aura",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
- "sp-timestamp 35.0.0",
+ "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2637,25 +2003,25 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "dyn-clone",
  "futures",
  "log",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-babe",
  "schnellru",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.41.0",
+ "sp-consensus-slots",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
- "sp-timestamp 35.0.0",
+ "sp-runtime",
+ "sp-timestamp",
  "sp-trie 38.0.0",
- "sp-version 38.0.0",
+ "sp-version",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -2667,10 +2033,10 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "anyhow",
  "async-trait",
- "cumulus-primitives-parachain-inherent 0.17.0",
+ "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "thiserror 1.0.69",
 ]
@@ -2688,16 +2054,16 @@ dependencies = [
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "sc-client-api",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
- "sp-version 38.0.0",
+ "sp-version",
  "tracing",
 ]
 
@@ -2707,16 +2073,16 @@ version = "0.15.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-parachain-inherent 0.17.0",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-storage 22.0.0",
  "sp-trie 38.0.0",
@@ -2729,7 +2095,7 @@ version = "0.21.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
@@ -2737,15 +2103,15 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "sc-client-api",
  "sc-consensus",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-consensus",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-runtime 40.1.0",
- "sp-version 38.0.0",
+ "sp-maybe-compressed-blob",
+ "sp-runtime",
+ "sp-version",
  "tracing",
 ]
 
@@ -2759,13 +2125,13 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-proof-size-hostfunction 0.11.0",
+ "cumulus-primitives-core",
+ "cumulus-primitives-proof-size-hostfunction",
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
  "futures",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
@@ -2777,32 +2143,13 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-transaction-pool 35.0.0",
-]
-
-[[package]]
-name = "cumulus-pallet-aura-ext"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8af48090936c45483d489ee681acb54277763586b53fa3dbd17173aa474fc"
-dependencies = [
- "cumulus-pallet-parachain-system 0.15.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "pallet-aura 35.0.0",
- "pallet-timestamp 35.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 37.0.0",
- "sp-consensus-aura 0.39.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-transaction-pool",
 ]
 
 [[package]]
@@ -2810,53 +2157,16 @@ name = "cumulus-pallet-aura-ext"
 version = "0.18.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "cumulus-pallet-parachain-system 0.18.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-aura 38.0.0",
- "pallet-timestamp 38.0.0",
+ "cumulus-pallet-parachain-system",
+ "frame-support",
+ "frame-system",
+ "pallet-aura",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 39.0.0",
- "sp-consensus-aura 0.41.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "cumulus-pallet-parachain-system"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300d5509bd8ac95bafe158fa475278315175a4eb0422c2cd82e08e8b9dde035c"
-dependencies = [
- "bytes",
- "cumulus-pallet-parachain-system-proc-macro 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cumulus-primitives-core 0.14.0",
- "cumulus-primitives-parachain-inherent 0.14.0",
- "cumulus-primitives-proof-size-hostfunction 0.9.0",
- "environmental",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-message-queue 39.0.2",
- "parity-scale-codec",
- "polkadot-parachain-primitives 13.0.0",
- "polkadot-runtime-common 15.0.0",
- "polkadot-runtime-parachains 15.0.4",
- "scale-info",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
- "sp-version 36.0.0",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "trie-db",
+ "sp-application-crypto",
+ "sp-consensus-aura",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -2865,46 +2175,34 @@ version = "0.18.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "bytes",
- "cumulus-pallet-parachain-system-proc-macro 0.6.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-parachain-inherent 0.17.0",
- "cumulus-primitives-proof-size-hostfunction 0.11.0",
+ "cumulus-pallet-parachain-system-proc-macro",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-message-queue 42.0.0",
+ "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-runtime-common 18.0.0",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "scale-info",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-trie 38.0.0",
- "sp-version 38.0.0",
+ "sp-version",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
+ "staging-xcm-builder",
  "trie-db",
-]
-
-[[package]]
-name = "cumulus-pallet-parachain-system-proc-macro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbaf3a1ce23ac8476481484fef5f4d500cbd15b4dad6380ce1d28134b0c1f7"
-dependencies = [
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -2916,21 +2214,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "cumulus-pallet-session-benchmarking"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506daacefa861aa2909b64f26e76495ce029227fd8355b97e074cc1d5dc54ab2"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "pallet-session 36.0.0",
- "parity-scale-codec",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2938,29 +2221,12 @@ name = "cumulus-pallet-session-benchmarking"
 version = "20.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-session 39.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
  "parity-scale-codec",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "cumulus-pallet-xcm"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5224285f60e5159bab549f458079d606a7f95ef779def8b89f1a244dc7cf81"
-dependencies = [
- "cumulus-primitives-core 0.14.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -2968,81 +2234,39 @@ name = "cumulus-pallet-xcm"
 version = "0.18.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "staging-xcm 15.0.1",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adf5409618b21e754fef0ac70f257878d22d61c48fdeefcab666835dcb8e0f0"
-dependencies = [
- "bounded-collections",
- "bp-xcm-bridge-hub-router 0.13.0",
- "cumulus-primitives-core 0.14.0",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-message-queue 39.0.2",
- "parity-scale-codec",
- "polkadot-runtime-common 15.0.0",
- "polkadot-runtime-parachains 15.0.4",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
-]
-
-[[package]]
-name = "cumulus-pallet-xcmp-queue"
 version = "0.18.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "bounded-collections",
- "bp-xcm-bridge-hub-router 0.15.0",
- "cumulus-primitives-core 0.17.0",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "bp-xcm-bridge-hub-router",
+ "cumulus-primitives-core",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-message-queue 42.0.0",
+ "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-runtime-common 18.0.0",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
-]
-
-[[package]]
-name = "cumulus-primitives-aura"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7977947ad43a4cbc532ca33abcde136ae3deffdc7168b2ae253d73ccd371e4"
-dependencies = [
- "parity-scale-codec",
- "polkadot-core-primitives 14.0.0",
- "polkadot-primitives 14.0.0",
- "sp-api 33.0.0",
- "sp-consensus-aura 0.39.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -3050,26 +2274,8 @@ name = "cumulus-primitives-aura"
 version = "0.16.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "sp-api 35.0.0",
- "sp-consensus-aura 0.41.0",
-]
-
-[[package]]
-name = "cumulus-primitives-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e64b89a839d5cfabebc1c797936e5eee791d0fa2322d91e86f8440a743ddb"
-dependencies = [
- "parity-scale-codec",
- "polkadot-core-primitives 14.0.0",
- "polkadot-parachain-primitives 13.0.0",
- "polkadot-primitives 14.0.0",
- "scale-info",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
- "staging-xcm 14.0.3",
+ "sp-api",
+ "sp-consensus-aura",
 ]
 
 [[package]]
@@ -3078,57 +2284,28 @@ version = "0.17.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 16.0.0",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "scale-info",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-api",
+ "sp-runtime",
  "sp-trie 38.0.0",
  "staging-xcm 15.0.1",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df521e13b48278b86d02c61d6e44036d6d263deb5aaec4838b1751da8988d3d2"
-dependencies = [
- "async-trait",
- "cumulus-primitives-core 0.14.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-inherents 33.0.0",
- "sp-runtime 38.0.1",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
-]
-
-[[package]]
-name = "cumulus-primitives-parachain-inherent"
 version = "0.17.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-trie 38.0.0",
-]
-
-[[package]]
-name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f973d2a7262c90e48dcd42062bcb1e0fbf48bbcdac4ea6df3d85212d8d8be5d"
-dependencies = [
- "sp-externalities 0.29.0",
- "sp-runtime-interface 28.0.0",
- "sp-trie 36.0.0",
 ]
 
 [[package]]
@@ -3146,37 +2323,16 @@ name = "cumulus-primitives-storage-weight-reclaim"
 version = "9.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-proof-size-hostfunction 0.11.0",
+ "cumulus-primitives-core",
+ "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "cumulus-primitives-utility"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05742c520065e3870d419683113ed7f6d35de66f0c80af6828e7878d1bb0ea94"
-dependencies = [
- "cumulus-primitives-core 0.14.0",
- "frame-support 36.0.1",
- "log",
- "pallet-asset-conversion 18.0.0",
- "parity-scale-codec",
- "polkadot-runtime-common 15.0.0",
- "polkadot-runtime-parachains 15.0.4",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3184,16 +2340,16 @@ name = "cumulus-primitives-utility"
 version = "0.18.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
+ "cumulus-primitives-core",
+ "frame-support",
  "log",
- "pallet-asset-conversion 21.0.0",
+ "pallet-asset-conversion",
  "parity-scale-codec",
- "polkadot-runtime-common 18.0.0",
- "sp-runtime 40.1.0",
+ "polkadot-runtime-common",
+ "sp-runtime",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -3202,7 +2358,7 @@ version = "0.22.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
@@ -3213,10 +2369,10 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
 ]
 
@@ -3226,16 +2382,16 @@ version = "0.21.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "futures",
  "jsonrpsee-core 0.24.8",
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-state-machine 0.44.0",
- "sp-version 38.0.0",
+ "sp-version",
  "thiserror 1.0.69",
 ]
 
@@ -3246,16 +2402,16 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "array-bytes",
  "async-trait",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
- "polkadot-core-primitives 16.0.0",
+ "polkadot-core-primitives",
  "polkadot-network-bridge",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "polkadot-service",
  "sc-authority-discovery",
  "sc-client-api",
@@ -3264,11 +2420,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-consensus-babe",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -3280,7 +2436,7 @@ version = "0.21.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "either",
  "futures",
@@ -3299,14 +2455,14 @@ dependencies = [
  "serde_json",
  "smoldot 0.11.0",
  "smoldot-light 0.9.0",
- "sp-api 35.0.0",
- "sp-authority-discovery 35.0.0",
- "sp-consensus-babe 0.41.0",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-consensus-babe",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-storage 22.0.0",
- "sp-version 38.0.0",
+ "sp-version",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -3320,10 +2476,10 @@ name = "cumulus-test-relay-sproof-builder"
 version = "0.17.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
- "sp-runtime 40.1.0",
+ "polkadot-primitives",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-trie 38.0.0",
 ]
@@ -3917,41 +3073,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "emulated-integration-tests-common"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "asset-test-utils",
- "bp-messages 0.19.0",
- "bp-xcm-bridge-hub",
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
- "pallet-assets 41.0.0",
- "pallet-balances 40.0.0",
- "pallet-bridge-messages",
- "pallet-message-queue 42.0.0",
- "pallet-xcm 18.0.0",
- "pallet-xcm-bridge-hub",
- "parachains-common 19.0.0",
- "parity-scale-codec",
- "paste",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-parachains 18.0.1",
- "sc-consensus-grandpa",
- "sp-authority-discovery 35.0.0",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-beefy 23.0.0",
- "sp-core 35.0.0",
- "sp-keyring 40.0.0",
- "sp-runtime 40.1.0",
- "staging-xcm 15.0.1",
- "xcm-emulator",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,41 +3218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethabi-decode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d398648d65820a727d6a81e58b962f874473396a047e4c30bafe3240953417"
-dependencies = [
- "ethereum-types 0.14.1",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethabi-decode"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52029c4087f9f01108f851d0d02df9c21feb5660a19713466724b7f95bd2d773"
-dependencies = [
- "ethereum-types 0.15.1",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec 0.6.0",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
 name = "ethbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,26 +3226,10 @@ dependencies = [
  "crunchy",
  "fixed-hash",
  "impl-codec 0.7.0",
- "impl-rlp 0.4.0",
+ "impl-rlp",
  "impl-serde 0.5.0",
  "scale-info",
  "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash",
- "impl-codec 0.6.0",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
- "scale-info",
- "uint 0.9.5",
 ]
 
 [[package]]
@@ -4168,10 +3238,10 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
 dependencies = [
- "ethbloom 0.14.1",
+ "ethbloom",
  "fixed-hash",
  "impl-codec 0.7.0",
- "impl-rlp 0.4.0",
+ "impl-rlp",
  "impl-serde 0.5.0",
  "primitive-types 0.13.1",
  "scale-info",
@@ -4470,49 +3540,23 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709b26657ebbba53dc7bb616577375ca462b20fef1b00e8d9b20d2435e87f7bc"
-dependencies = [
- "frame-support 36.0.1",
- "frame-support-procedural 30.0.4",
- "frame-system 36.1.0",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-runtime-interface 28.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 21.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-support-procedural 31.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-support-procedural",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-runtime-interface 29.0.0",
  "sp-storage 22.0.0",
  "static_assertions",
@@ -4529,10 +3573,10 @@ dependencies = [
  "clap",
  "comfy-table",
  "cumulus-client-parachain-inherent",
- "cumulus-primitives-proof-size-hostfunction 0.11.0",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "cumulus-primitives-proof-size-hostfunction",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "gethostname",
  "handlebars",
  "hex",
@@ -4540,8 +3584,8 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "rand",
  "rand_pcg",
  "sc-block-builder",
@@ -4555,24 +3599,24 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-database",
  "sp-externalities 0.30.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-storage 22.0.0",
- "sp-timestamp 35.0.0",
- "sp-transaction-pool 35.0.0",
+ "sp-timestamp",
+ "sp-transaction-pool",
  "sp-trie 38.0.0",
- "sp-version 38.0.0",
+ "sp-version",
  "sp-wasm-interface 21.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "subxt",
  "subxt-signer",
@@ -4583,42 +3627,12 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8156f209055d352994ecd49e19658c6b469d7c6de923bd79868957d0dcfb6f71"
-dependencies = [
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "frame-election-provider-solution-type"
-version = "14.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "frame-election-provider-support"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ec289ebad5e601bb165cf7eb6ec2179ae34280ee310d0710a3111d4f8f8f94"
-dependencies = [
- "frame-election-provider-solution-type 14.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-npos-elections 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4626,35 +3640,15 @@ name = "frame-election-provider-support"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-election-provider-solution-type 14.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-election-provider-solution-type",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
- "sp-npos-elections 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "frame-executive"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d878830330eaa9e8b886279c338556b05702d0059989cb51cfb226b70bf3fa4"
-dependencies = [
- "aquamarine",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "frame-try-runtime 0.42.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 17.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-npos-elections",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4663,15 +3657,15 @@ version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "aquamarine",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-try-runtime 0.45.0",
+ "frame-support",
+ "frame-system",
+ "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
 
@@ -4712,76 +3706,18 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata-hash-extension"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf37fc730bf4b51e82a34c6357eebe32c04dbacf6525e0a7b9726f6a17ec9427"
-dependencies = [
- "array-bytes",
- "docify",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
-]
-
-[[package]]
-name = "frame-metadata-hash-extension"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "array-bytes",
  "const-hex",
  "docify",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "frame-support"
-version = "36.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4d08149c28010bfa568dcfa832aea628fb794d4243794a13b1bdef1aa66fb1"
-dependencies = [
- "aquamarine",
- "array-bytes",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata 16.0.0",
- "frame-support-procedural 30.0.4",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api 33.0.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-genesis-builder 0.14.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-metadata-ir 0.7.0",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 17.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions",
- "tt-call",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4791,12 +3727,12 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "aquamarine",
  "array-bytes",
- "binary-merkle-tree 16.0.0",
+ "binary-merkle-tree",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata 18.0.0",
- "frame-support-procedural 31.0.0",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -4807,17 +3743,17 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-crypto-hashing-proc-macro",
  "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-metadata-ir 0.8.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
+ "sp-metadata-ir",
+ "sp-runtime",
+ "sp-staking",
  "sp-state-machine 0.44.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
@@ -4825,26 +3761,6 @@ dependencies = [
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "static_assertions",
  "tt-call",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "30.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8f9b6bc1517a6fcbf0b2377e5c8c6d39f5bb7862b191a59a9992081d63972d"
-dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse",
- "expander",
- "frame-support-procedural-tools 13.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.11.0",
- "macro_magic",
- "proc-macro-warning 1.0.2",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -4857,7 +3773,7 @@ dependencies = [
  "derive-syn-parse",
  "docify",
  "expander",
- "frame-support-procedural-tools 13.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "frame-support-procedural-tools",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning 1.0.2",
@@ -4870,34 +3786,10 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a088fd6fda5f53ff0c17fc7551ce8bd0ead14ba742228443c8196296a7369b"
-dependencies = [
- "frame-support-procedural-tools-derive 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "13.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support-procedural-tools-derive 12.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -4911,27 +3803,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "frame-system"
-version = "36.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d6a0e7bb6503facdcc6f8e19c83cd0bfc8bbbd268522b1a50e107dfc6b972d"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 36.0.1",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version 36.0.0",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4941,33 +3812,17 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 39.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-version 38.0.0",
+ "sp-version",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "frame-system-benchmarking"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15afc91c7780e18274dcea58ed1edb700c48d10e086a9785e3f6708099cd3250"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4975,23 +3830,13 @@ name = "frame-system-benchmarking"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "frame-system-rpc-runtime-api"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9e2b7b85e451e367f4fb85ff3295bd039e17f64de1906154d3976e2638ee8"
-dependencies = [
- "parity-scale-codec",
- "sp-api 33.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5001,20 +3846,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "docify",
  "parity-scale-codec",
- "sp-api 35.0.0",
-]
-
-[[package]]
-name = "frame-try-runtime"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6ba8b36a52775ad39ccfb45ff4ad814c3cb45ec74d0a4271889e00bd791c6c"
-dependencies = [
- "frame-support 36.0.1",
- "parity-scale-codec",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-api",
 ]
 
 [[package]]
@@ -5022,10 +3854,10 @@ name = "frame-try-runtime"
 version = "0.45.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5479,9 +4311,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -5489,7 +4318,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
 ]
 
 [[package]]
@@ -5498,7 +4327,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
  "serde",
 ]
@@ -6124,17 +4953,6 @@ dependencies = [
 
 [[package]]
 name = "impl-num-traits"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
-dependencies = [
- "integer-sqrt",
- "num-traits",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "impl-num-traits"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "803d15461ab0dcc56706adf266158acbc44ccf719bf7d0af30705f58b90a4b8c"
@@ -6146,20 +4964,11 @@ dependencies = [
 
 [[package]]
 name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp 0.5.2",
-]
-
-[[package]]
-name = "impl-rlp"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
- "rlp 0.6.1",
+ "rlp",
 ]
 
 [[package]]
@@ -6468,43 +5277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integration-tests"
-version = "0.0.0"
-dependencies = [
- "asset-hub-paseo-runtime",
- "asset-hub-westend-runtime",
- "asset-test-utils",
- "cumulus-primitives-core 0.17.0",
- "emulated-integration-tests-common",
- "frame-support 39.0.0",
- "pallet-assets 41.0.0",
- "pallet-balances 40.0.0",
- "pallet-message-queue 42.0.0",
- "pallet-xcm 18.0.0",
- "parity-scale-codec",
- "paseo-runtime",
- "paseo-runtime-constants",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-parachains 18.0.1",
- "pop-runtime-common",
- "pop-runtime-devnet",
- "pop-runtime-mainnet",
- "pop-runtime-testnet",
- "sp-authority-discovery 35.0.0",
- "sp-consensus-aura 0.41.0",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-beefy 23.0.0",
- "sp-consensus-grandpa 22.0.0",
- "sp-core 35.0.0",
- "sp-runtime 40.1.0",
- "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
- "tracing-subscriber",
- "westend-runtime",
- "westend-runtime-constants",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6587,10 +5359,10 @@ name = "ismp-parachain"
 version = "1.15.3"
 source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
 dependencies = [
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "cumulus-pallet-parachain-system",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "ismp",
  "log",
@@ -6599,10 +5371,10 @@ dependencies = [
  "primitive-types 0.13.1",
  "scale-info",
  "serde",
- "sp-consensus-aura 0.41.0",
- "sp-inherents 35.0.0",
+ "sp-consensus-aura",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-trie 38.0.0",
  "substrate-state-machine",
 ]
@@ -6614,7 +5386,7 @@ source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98
 dependencies = [
  "anyhow",
  "async-trait",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "ismp",
  "ismp-parachain",
@@ -6622,10 +5394,10 @@ dependencies = [
  "log",
  "pallet-ismp-runtime-api",
  "parity-scale-codec",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6633,8 +5405,8 @@ name = "ismp-parachain-runtime-api"
 version = "1.15.1"
 source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
 dependencies = [
- "cumulus-pallet-parachain-system 0.18.0",
- "sp-api 35.0.0",
+ "cumulus-pallet-parachain-system",
+ "sp-api",
 ]
 
 [[package]]
@@ -7098,21 +5870,6 @@ name = "keystream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33070833c9ee02266356de0c43f723152bd38bd96ddf52c82b3af10c9138b28"
-
-[[package]]
-name = "kusama-runtime-constants"
-version = "1.0.0"
-source = "git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4#3b18d942c766c7f358da50608b44edbe218284a4"
-dependencies = [
- "frame-support 36.0.1",
- "polkadot-primitives 14.0.0",
- "polkadot-runtime-common 15.0.0",
- "smallvec",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm-builder 15.0.0",
-]
 
 [[package]]
 name = "kvdb"
@@ -7876,15 +6633,6 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
-dependencies = [
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "lru"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
@@ -8153,13 +6901,13 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-beefy 23.0.0",
+ "sp-consensus-beefy",
  "sp-core 35.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-mmr-primitives",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8170,11 +6918,11 @@ dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-mmr-primitives",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8772,45 +7520,25 @@ name = "pallet-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "ismp",
  "log",
- "pallet-assets 41.0.0",
- "pallet-balances 40.0.0",
+ "pallet-assets",
+ "pallet-balances",
  "pallet-ismp",
  "pallet-nfts 31.0.0",
- "pallet-xcm 18.0.0",
+ "pallet-xcm",
  "parity-scale-codec",
  "pop-chain-extension",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
-]
-
-[[package]]
-name = "pallet-asset-conversion"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f726ebb59401c1844a4a8703047bdafcd99a1827cd5d8b2c82abeb8948a7f25b"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -8818,82 +7546,17 @@ name = "pallet-asset-conversion"
 version = "21.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-asset-conversion-ops"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "log",
- "pallet-asset-conversion 21.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-asset-conversion-tx-payment"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0fde03a96382f4dbe37ef95cb4ef7aade7c0be410cb6c888eda911c94af3eaf"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "pallet-asset-conversion 18.0.0",
- "pallet-transaction-payment 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pallet-asset-conversion-tx-payment"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-asset-conversion 21.0.0",
- "pallet-transaction-payment 39.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-asset-rate"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e806842bec955190ec64f8b2179f74f5355137c4cadf04f3269e6196cd19caf9"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8901,32 +7564,13 @@ name = "pallet-asset-rate"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-asset-tx-payment"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100a180dfbf30a1c872100ec2dae8a61c0f5e8b3f2d3a5cbb34093826293e2ab"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "pallet-transaction-payment 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8934,34 +7578,16 @@ name = "pallet-asset-tx-payment"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-transaction-payment 39.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-assets"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79ef6a7763fc08177f014052469ee12aefcdad0d99a747372360c2f648d2cc4"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8969,48 +7595,15 @@ name = "pallet-assets"
 version = "41.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-assets-freezer"
-version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "log",
- "pallet-assets 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-aura"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0861b2a1ad6526948567bb59a3fdc4c7f02ee79b07be8b931a544350ec35ab0c"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-timestamp 35.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 37.0.0",
- "sp-consensus-aura 0.39.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9018,32 +7611,15 @@ name = "pallet-aura"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-timestamp 38.0.0",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 39.0.0",
- "sp-consensus-aura 0.41.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-authority-discovery"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2c3666a476132f5846fe4d5e1961a923a58a0f54d873d84566f24ffaa3684f"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "pallet-session 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 37.0.0",
- "sp-authority-discovery 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-consensus-aura",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9051,29 +7627,14 @@ name = "pallet-authority-discovery"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-session 39.0.0",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 39.0.0",
- "sp-authority-discovery 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-authorship"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38885846dbcf03b025fdbd7edb3649046dbc68fa0b419ffe8837ef853a10d31f"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-authority-discovery",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9081,37 +7642,12 @@ name = "pallet-authorship"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-babe"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23d2d814e3cb793659fcf84533f66fdf0ed9cccb66cb2225851f482843ed096"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-authorship 36.0.0",
- "pallet-session 36.0.0",
- "pallet-timestamp 35.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 37.0.0",
- "sp-consensus-babe 0.39.0",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9119,45 +7655,22 @@ name = "pallet-babe"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 39.0.0",
- "pallet-session 39.0.0",
- "pallet-timestamp 38.0.0",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 39.0.0",
- "sp-consensus-babe 0.41.0",
+ "sp-application-crypto",
+ "sp-consensus-babe",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-bags-list"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af34fa3fb6a0abe3577e435988039a9e441f6705ae2d3ad627a23e3f705baa2d"
-dependencies = [
- "aquamarine",
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-balances 37.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 17.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9167,71 +7680,33 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "aquamarine",
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878e240962d3887f0e0654ac343a18845adb95ad493c9d4d5e803c015d4a4c3"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pallet-balances"
 version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-beefy"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715dfcd1bf3f1f37af6335d4eb3cef921e746ac54721e2258c4fd968b61eb009"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-authorship 36.0.0",
- "pallet-session 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-consensus-beefy 20.0.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9239,44 +7714,18 @@ name = "pallet-beefy"
 version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 39.0.0",
- "pallet-session 39.0.0",
+ "pallet-authorship",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-consensus-beefy 23.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-beefy-mmr"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d70c6f872eb3f2635355ccbea944a4f9ea411c0aa25f6f1a15219e8da11ad2"
-dependencies = [
- "array-bytes",
- "binary-merkle-tree 15.0.1",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-beefy 36.0.0",
- "pallet-mmr 35.0.0",
- "pallet-session 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-consensus-beefy 20.0.0",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-consensus-beefy",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9285,42 +7734,23 @@ version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "array-bytes",
- "binary-merkle-tree 16.0.0",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "binary-merkle-tree",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-beefy 40.0.0",
- "pallet-mmr 39.0.0",
- "pallet-session 39.0.0",
+ "pallet-beefy",
+ "pallet-mmr",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
- "sp-consensus-beefy 23.0.0",
+ "sp-api",
+ "sp-consensus-beefy",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
-]
-
-[[package]]
-name = "pallet-bounties"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0566499e74ba4b7ccbd1b667eef0dab76ca28402a8d501e22b73a363717b05a9"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-treasury 35.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -9328,55 +7758,16 @@ name = "pallet-bounties"
 version = "38.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-treasury 38.0.0",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-bridge-messages"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-header-chain 0.19.0",
- "bp-messages 0.19.0",
- "bp-runtime 0.19.0",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-trie 38.0.0",
-]
-
-[[package]]
-name = "pallet-broker"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0d652c399b6ed776ee3322e60f40e323f86b413719d7696eddb8f64c368ac0"
-dependencies = [
- "bitvec",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9385,36 +7776,16 @@ version = "0.18.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "bitvec",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-child-bounties"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e351f103ebbdd1eb095da8c2379caccc82ebc59a740c2731693d2204286b83"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-bounties 35.0.0",
- "pallet-treasury 35.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9422,38 +7793,17 @@ name = "pallet-child-bounties"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-bounties 38.0.1",
- "pallet-treasury 38.0.0",
+ "pallet-bounties",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-collator-selection"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f660cc09f2f277a3976da2eef856b5c725ab7ad1192902ef7f4e4bafd992f04f"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-authorship 36.0.0",
- "pallet-balances 37.0.0",
- "pallet-session 36.0.0",
- "parity-scale-codec",
- "rand",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9461,18 +7811,18 @@ name = "pallet-collator-selection"
 version = "20.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-session 39.0.0",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-session",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9481,15 +7831,15 @@ version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9499,12 +7849,12 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi 12.0.1",
  "parity-scale-codec",
@@ -9514,13 +7864,13 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
+ "staging-xcm-builder",
  "wasm-instrument",
  "wasmi 0.32.3",
 ]
@@ -9559,51 +7909,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9033f0d23500bbc39298fd50c07b89a2f2d9f07300139b4df8005995ef683875"
-dependencies = [
- "assert_matches",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pallet-conviction-voting"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-delegated-staking"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0596ec5ab55e02b1b5637b3ec2b99027d036fe97a1ab4733ae105474dfa727cf"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9611,14 +7928,14 @@ name = "pallet-delegated-staking"
 version = "6.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9626,40 +7943,16 @@ name = "pallet-democracy"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-election-provider-multi-phase"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1090fdc6ccdd8ff08c60000c970428baaaf0b33e7a6b01a91ec8b697a650a3"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-election-provider-support-benchmarking 35.0.0",
- "parity-scale-codec",
- "rand",
- "scale-info",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-npos-elections 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "strum 0.26.3",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9667,36 +7960,21 @@ name = "pallet-election-provider-multi-phase"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-election-provider-support-benchmarking 38.0.0",
+ "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "rand",
  "scale-info",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-npos-elections 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-npos-elections",
+ "sp-runtime",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "pallet-election-provider-support-benchmarking"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93475989d2f6900caf8f1c847a55d909295c156525a7510c5f1dde176ec7c714"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "sp-npos-elections 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -9704,12 +7982,12 @@ name = "pallet-election-provider-support-benchmarking"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-system",
  "parity-scale-codec",
- "sp-npos-elections 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-npos-elections",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9717,37 +7995,17 @@ name = "pallet-elections-phragmen"
 version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-npos-elections 35.0.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-fast-unstake"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155f4f762513e0287320411415c76a647152799ad33db1785c9b71c36a14575"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9756,40 +8014,16 @@ version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-grandpa"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8244b686d5cae6a8af1557ed0f49db08f812f0e7942a8d2da554b4da8a69daf0"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-authorship 36.0.0",
- "pallet-session 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 37.0.0",
- "sp-consensus-grandpa 20.0.0",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9797,39 +8031,21 @@ name = "pallet-grandpa"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 39.0.0",
- "pallet-session 39.0.0",
+ "pallet-authorship",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 39.0.0",
- "sp-consensus-grandpa 22.0.0",
+ "sp-application-crypto",
+ "sp-consensus-grandpa",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-identity"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4555795a3e0e3aa49ea432b7afecb9c71a7db8793a99c68bd8dd3a52a12571f3"
-dependencies = [
- "enumflags2",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9838,35 +8054,14 @@ version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-im-online"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa761292e95020304b58b50e5187f8bb82f557c8c2d013e3c96ab41d611873b0"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-authorship 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 37.0.0",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9874,36 +8069,18 @@ name = "pallet-im-online"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 39.0.0",
+ "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-indices"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b183880ad5efae06afe6066e76f2bac5acf67f34b3cfab7352ceec46accf4b45"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-keyring 38.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9911,15 +8088,15 @@ name = "pallet-indices"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-runtime 40.1.0",
+ "sp-keyring",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9929,19 +8106,19 @@ source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98
 dependencies = [
  "anyhow",
  "fortuples",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "ismp",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-mmr-primitives",
+ "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
 
@@ -9951,7 +8128,7 @@ version = "1.15.3"
 source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
 dependencies = [
  "anyhow",
- "frame-system 39.1.0",
+ "frame-system",
  "hash-db",
  "hex",
  "hex-literal",
@@ -9964,11 +8141,11 @@ dependencies = [
  "sc-rpc",
  "serde",
  "serde_json",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-mmr-primitives",
+ "sp-runtime",
  "sp-storage 22.0.0",
  "sp-trie 38.0.0",
  "tower",
@@ -9985,8 +8162,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "serde",
- "sp-api 35.0.0",
- "sp-mmr-primitives 35.0.0",
+ "sp-api",
+ "sp-mmr-primitives",
 ]
 
 [[package]]
@@ -9994,36 +8171,15 @@ name = "pallet-membership"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-message-queue"
-version = "39.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e565e64035684e8768e00e54aaa4a0c8e69c83703899d74e8de57ed5fde399da"
-dependencies = [
- "environmental",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10032,16 +8188,16 @@ version = "42.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "environmental",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
 
@@ -10052,34 +8208,15 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "cfg-if",
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-mmr"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8ccec82827413f031689fef4c714fdb0213d58c7a6e208d33f5eab80483770"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-mmr-primitives 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10087,50 +8224,33 @@ name = "pallet-mmr"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-mmr-primitives",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-motion"
 version = "4.0.0-dev"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "pallet-collective",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-multisig"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be58483d827602eb8353ecf36aed65c857f0974db5d27981831e5ebf853040bd"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10149,34 +8269,15 @@ name = "pallet-nft-fractionalization"
 version = "22.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-assets 41.0.0",
+ "pallet-assets",
  "pallet-nfts 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-nfts"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1cd476809de3840e19091a083d5a79178af1f108ad489706e1f9e04c8836a4"
-dependencies = [
- "enumflags2",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10184,17 +8285,17 @@ name = "pallet-nfts"
 version = "31.0.0"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10203,27 +8304,15 @@ version = "33.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-nfts-runtime-api"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ca7a0446d2d3c27f726a016c6366218df2e0bfef9ed35886b252cfa9757f6c"
-dependencies = [
- "pallet-nfts 30.0.0",
- "parity-scale-codec",
- "sp-api 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10233,7 +8322,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "pallet-nfts 33.0.0",
  "parity-scale-codec",
- "sp-api 35.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -10241,34 +8330,14 @@ name = "pallet-nis"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-nomination-pools"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f8c994eb7298a394b58f98afd520b521b5d46f6f39eade4657eeaac9962471"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-balances 37.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 17.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10276,71 +8345,37 @@ name = "pallet-nomination-pools"
 version = "37.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ee599f2861e55fc6113c01e9b14d6e85fda46bac36a906b5dd5a951fa0455c"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "pallet-bags-list 35.0.0",
- "pallet-delegated-staking 3.0.0",
- "pallet-nomination-pools 33.0.0",
- "pallet-staking 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-runtime-interface 28.0.0",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pallet-nomination-pools-benchmarking"
 version = "37.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-bags-list 38.0.0",
- "pallet-delegated-staking 6.0.0",
- "pallet-nomination-pools 37.0.0",
- "pallet-staking 39.0.1",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "pallet-bags-list",
+ "pallet-delegated-staking",
+ "pallet-nomination-pools",
+ "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-runtime-interface 29.0.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-nomination-pools-runtime-api"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2906899d8f029780f0d9da77b90ae86f42bcfda5ac402c931406cd84852012ed"
-dependencies = [
- "pallet-nomination-pools 33.0.0",
- "parity-scale-codec",
- "sp-api 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10348,27 +8383,9 @@ name = "pallet-nomination-pools-runtime-api"
 version = "35.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "pallet-nomination-pools 37.0.0",
+ "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 35.0.0",
-]
-
-[[package]]
-name = "pallet-offences"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4859e7bb2af46d2e0f137c2f777adf39f0e5d4d188226158d599f1cfcfb76b9e"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-balances 37.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-api",
 ]
 
 [[package]]
@@ -10376,40 +8393,15 @@ name = "pallet-offences"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-offences-benchmarking"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4351b0edafcdf3240f0471c638b39d2c981bde9d17c0172536a0aa3b7c3097ef"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-babe 36.0.0",
- "pallet-balances 37.0.0",
- "pallet-grandpa 36.0.0",
- "pallet-im-online 35.0.0",
- "pallet-offences 35.0.0",
- "pallet-session 36.0.0",
- "pallet-staking 36.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10417,41 +8409,22 @@ name = "pallet-offences-benchmarking"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-babe 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-grandpa 39.0.0",
- "pallet-im-online 38.0.0",
- "pallet-offences 38.0.0",
- "pallet-session 39.0.0",
- "pallet-staking 39.0.1",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-grandpa",
+ "pallet-im-online",
+ "pallet-offences",
+ "pallet-session",
+ "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-parameters"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d9a81a93202105a660e6aa3d3f81638bdd109ca0497f3e528529cd52d034db"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10460,33 +8433,15 @@ version = "0.10.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-preimage"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ac726abc5b1bcd6c8f783514b8e1a48be32c7d15e0b263e4bc28cc1e4e7763"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10494,31 +8449,15 @@ name = "pallet-preimage"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-proxy"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e12680e176607815a78a0cd10a52af50790292cb950404f30a885e2a7229e9"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10536,9 +8475,9 @@ name = "pallet-ranked-collective"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
@@ -10546,7 +8485,7 @@ dependencies = [
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10554,33 +8493,13 @@ name = "pallet-recovery"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-referenda"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c906a9c4573eb58de4134ec7180bf12c6769df2b9859dae8adcbc5fce78add"
-dependencies = [
- "assert_matches",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10589,16 +8508,16 @@ version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10609,34 +8528,34 @@ dependencies = [
  "bitflags 1.3.2",
  "derive_more 0.99.19",
  "environmental",
- "ethereum-types 0.15.1",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "ethereum-types",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hex",
  "impl-trait-for-tuples",
  "jsonrpsee 0.24.8",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "pallet-revive-fixtures",
  "pallet-revive-proc-macro",
  "pallet-revive-uapi",
- "pallet-transaction-payment 39.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "paste",
  "polkavm 0.13.0",
- "rlp 0.6.1",
+ "rlp",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
+ "staging-xcm-builder",
  "subxt-signer",
 ]
 
@@ -10646,13 +8565,13 @@ version = "0.3.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "anyhow",
- "frame-system 39.1.0",
+ "frame-system",
  "log",
  "parity-wasm",
  "polkavm-linker 0.14.0",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "tempfile",
  "toml 0.8.19",
 ]
@@ -10684,32 +8603,13 @@ name = "pallet-root-testing"
 version = "15.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-scheduler"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b170d6aa191197d3f50b1193925546972ffc394376ead4d2739eb40909b73c85"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10718,38 +8618,15 @@ version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "pallet-session"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c92b24c911c2cfa5351616edc7f2f93427ea6f4f95efdb13f0f5d51997939c3"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-timestamp 35.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-staking 33.0.0",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
 ]
 
 [[package]]
@@ -10757,54 +8634,36 @@ name = "pallet-session"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-timestamp 38.0.0",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
  "sp-state-machine 0.44.0",
  "sp-trie 38.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd02aaf5f10734670346677042ece94fae20dcd5436eafeb9b429d8d6d5b6385"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "pallet-session 36.0.0",
- "pallet-staking 36.0.0",
- "parity-scale-codec",
- "rand",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pallet-session-benchmarking"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-session 39.0.0",
- "pallet-staking 39.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "pallet-staking",
  "parity-scale-codec",
  "rand",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
+ "sp-runtime",
+ "sp-session",
 ]
 
 [[package]]
@@ -10812,40 +8671,16 @@ name = "pallet-society"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha",
  "scale-info",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-staking"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbebdb060417654f215fc6f03675e5f44cfc83837d9e523e1b8fd9a4a2e1bdc2"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-authorship 36.0.0",
- "pallet-session 36.0.0",
- "parity-scale-codec",
- "rand_chacha",
- "scale-info",
- "serde",
- "sp-application-crypto 37.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10853,43 +8688,21 @@ name = "pallet-staking"
 version = "39.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 39.0.0",
- "pallet-session 39.0.0",
+ "pallet-authorship",
+ "pallet-session",
  "parity-scale-codec",
  "rand_chacha",
  "scale-info",
  "serde",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-staking-reward-curve"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5e6b1d8ee9d3f6894c5abd8c3e17737ed738c9854f87bfd16239741b7f4d5d"
-dependencies = [
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "pallet-staking-reward-fn"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988a7ebeacc84d4bdb0b12409681e956ffe35438447d8f8bc78db547cffb6ebc"
-dependencies = [
- "log",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10899,17 +8712,6 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "log",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "pallet-staking-runtime-api"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3350ef1795b832f4adc464e88fb6d44827bd3f98701b0b0bbee495267b444a92"
-dependencies = [
- "parity-scale-codec",
- "sp-api 33.0.0",
- "sp-staking 33.0.0",
 ]
 
 [[package]]
@@ -10918,26 +8720,8 @@ version = "25.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "parity-scale-codec",
- "sp-api 35.0.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "pallet-state-trie-migration"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07f8626f4ff62ac79d6ad0bd01fab7645897ce35706ddb95fa084e75be9306d"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10945,32 +8729,15 @@ name = "pallet-state-trie-migration"
 version = "43.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-sudo"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd2a8797c1bb3d3897b4f87a7716111da5eeb8561345277b6e6d70349ec8b35"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10979,34 +8746,13 @@ version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-timestamp"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae789d344be857679b0b98b28a67c747119724847f81d704d3fd03ee13fb6841"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 21.0.0",
- "sp-timestamp 33.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11015,17 +8761,17 @@ version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-storage 22.0.0",
- "sp-timestamp 35.0.0",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -11033,34 +8779,17 @@ name = "pallet-tips"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-treasury 38.0.0",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fb6114223c8d967c3c2f21cbc845e8ea604ff7e21a8e59d119d5a9257ba886"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11068,15 +8797,15 @@ name = "pallet-transaction-payment"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11085,27 +8814,14 @@ version = "42.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "jsonrpsee 0.24.8",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
+ "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "pallet-transaction-payment-rpc-runtime-api"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bad1700ad7eb5ab254189e1df894d1d16b3626a3c4b9c45259ec4d9efc262c"
-dependencies = [
- "pallet-transaction-payment 36.0.0",
- "parity-scale-codec",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -11113,31 +8829,11 @@ name = "pallet-transaction-payment-rpc-runtime-api"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "pallet-transaction-payment 39.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-api",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "pallet-treasury"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c502615bb4fdd02856a131cb2a612ad40c26435ec938f65f11cae4ff230812b"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "pallet-balances 37.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -11146,64 +8842,17 @@ version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-uniques"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a59e8599a8c19908e934645f845b5cb546cef1f08745319db7e5b9c24f9e0e4"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pallet-uniques"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-utility"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3238fe6ad00da6a137be115904c39cab97eb5c7f03da0bb1a20de1bef03f0c71"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11211,30 +8860,14 @@ name = "pallet-utility"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-vesting"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f7f0f4fe5e1d851e85d81e5e73b6f929f0c35af786ce8be9c9e3363717c136"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11242,29 +8875,13 @@ name = "pallet-vesting"
 version = "39.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-whitelist"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4f27640279229eb73fde0cb06e98b799305e6b0bc724f4dfbef2001ab4ad00"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11272,38 +8889,13 @@ name = "pallet-whitelist"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "pallet-xcm"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7409458b7fedc5c7d46459da154ccc2dc22a843ce08e8ab6c1743ef5cf972c"
-dependencies = [
- "bounded-collections",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-balances 37.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
- "xcm-runtime-apis 0.2.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11312,41 +8904,21 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-balances 40.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "tracing",
- "xcm-runtime-apis 0.5.0",
-]
-
-[[package]]
-name = "pallet-xcm-benchmarks"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f177a171203cc0bec3cff1bdd5d3b926abfbd0ecf347e044b147194e664f717"
-dependencies = [
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -11354,110 +8926,17 @@ name = "pallet-xcm-benchmarks"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
-]
-
-[[package]]
-name = "pallet-xcm-bridge-hub"
-version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-messages 0.19.0",
- "bp-runtime 0.19.0",
- "bp-xcm-bridge-hub",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "log",
- "pallet-bridge-messages",
- "parity-scale-codec",
- "scale-info",
- "sp-core 35.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
-]
-
-[[package]]
-name = "pallet-xcm-bridge-hub-router"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48bd38d4061a51f263f4c08021e66100e16cbda9978fba163d2544637b31dab"
-dependencies = [
- "bp-xcm-bridge-hub-router 0.13.0",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
-]
-
-[[package]]
-name = "pallet-xcm-bridge-hub-router"
-version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "bp-xcm-bridge-hub-router 0.15.0",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 35.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
-]
-
-[[package]]
-name = "parachains-common"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9319e656eebdf161666e54a4d8e24f73137f702f01600247f7be650bc4d46167"
-dependencies = [
- "cumulus-primitives-core 0.14.0",
- "cumulus-primitives-utility 0.15.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "pallet-asset-tx-payment 36.0.0",
- "pallet-assets 37.0.0",
- "pallet-authorship 36.0.0",
- "pallet-balances 37.0.0",
- "pallet-collator-selection 17.0.0",
- "pallet-message-queue 39.0.2",
- "pallet-xcm 15.0.0",
- "parity-scale-codec",
- "polkadot-primitives 14.0.0",
- "scale-info",
- "sp-consensus-aura 0.39.0",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-parachain-info 0.15.0",
- "staging-xcm 14.0.3",
- "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -11465,59 +8944,29 @@ name = "parachains-common"
 version = "19.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-utility 0.18.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "cumulus-primitives-core",
+ "cumulus-primitives-utility",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-asset-tx-payment 39.0.0",
- "pallet-assets 41.0.0",
- "pallet-authorship 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-collator-selection 20.0.0",
- "pallet-message-queue 42.0.0",
- "pallet-xcm 18.0.0",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "pallet-message-queue",
+ "pallet-xcm",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "scale-info",
- "sp-consensus-aura 0.41.0",
+ "sp-consensus-aura",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "staging-parachain-info 0.18.0",
+ "sp-runtime",
+ "staging-parachain-info",
  "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
-]
-
-[[package]]
-name = "parachains-runtimes-test-utils"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-parachain-inherent 0.17.0",
- "cumulus-test-relay-sproof-builder",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "pallet-balances 40.0.0",
- "pallet-collator-selection 20.0.0",
- "pallet-session 39.0.0",
- "pallet-timestamp 38.0.0",
- "pallet-xcm 18.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "sp-consensus-aura 0.41.0",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-parachain-info 0.18.0",
- "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
+ "staging-xcm-executor",
+ "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -11532,12 +8981,6 @@ dependencies = [
  "serde",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "parity-bytes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b56e3a2420138bdb970f84dfb9c774aea80fa0e7371549eedec0d80c209c67"
 
 [[package]]
 name = "parity-db"
@@ -11585,35 +9028,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "parity-util-mem"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
-dependencies = [
- "cfg-if",
- "ethereum-types 0.14.1",
- "hashbrown 0.12.3",
- "impl-trait-for-tuples",
- "lru 0.8.1",
- "parity-util-mem-derive",
- "parking_lot 0.12.3",
- "primitive-types 0.12.2",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "parity-util-mem-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -11681,122 +9095,6 @@ name = "partial_sort"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7924d1d0ad836f665c9065e26d016c673ece3993f30d340068b16f282afc1156"
-
-[[package]]
-name = "paseo-runtime"
-version = "1.3.4"
-source = "git+https://github.com/paseo-network/runtimes?tag=v1.3.4#313b81aa2b2cb076b4f99c9b2bea040a8bcf709f"
-dependencies = [
- "binary-merkle-tree 15.0.1",
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-executive 36.0.0",
- "frame-metadata-hash-extension 0.4.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "frame-system-benchmarking 36.0.0",
- "frame-system-rpc-runtime-api 33.0.0",
- "frame-try-runtime 0.42.0",
- "hex-literal",
- "log",
- "pallet-asset-rate 15.0.0",
- "pallet-authority-discovery 36.0.0",
- "pallet-authorship 36.0.0",
- "pallet-babe 36.0.0",
- "pallet-bags-list 35.0.0",
- "pallet-balances 37.0.0",
- "pallet-beefy 36.0.0",
- "pallet-beefy-mmr 36.0.0",
- "pallet-bounties 35.0.0",
- "pallet-broker 0.15.0",
- "pallet-child-bounties 35.0.0",
- "pallet-conviction-voting 36.0.0",
- "pallet-election-provider-multi-phase 35.0.0",
- "pallet-election-provider-support-benchmarking 35.0.0",
- "pallet-fast-unstake 35.0.0",
- "pallet-grandpa 36.0.0",
- "pallet-indices 36.0.0",
- "pallet-message-queue 39.0.2",
- "pallet-mmr 35.0.0",
- "pallet-multisig 36.0.0",
- "pallet-nomination-pools 33.0.0",
- "pallet-nomination-pools-benchmarking 34.0.0",
- "pallet-nomination-pools-runtime-api 31.0.0",
- "pallet-offences 35.0.0",
- "pallet-offences-benchmarking 36.0.0",
- "pallet-parameters 0.7.0",
- "pallet-preimage 36.0.0",
- "pallet-proxy 36.0.0",
- "pallet-referenda 36.0.0",
- "pallet-scheduler 37.0.0",
- "pallet-session 36.0.0",
- "pallet-session-benchmarking 36.0.0",
- "pallet-staking 36.0.0",
- "pallet-staking-reward-curve",
- "pallet-staking-reward-fn 22.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-staking-runtime-api 21.0.0",
- "pallet-state-trie-migration 37.0.0",
- "pallet-sudo 36.0.0",
- "pallet-timestamp 35.0.0",
- "pallet-transaction-payment 36.0.0",
- "pallet-transaction-payment-rpc-runtime-api 36.0.0",
- "pallet-treasury 35.0.0",
- "pallet-utility 36.0.0",
- "pallet-vesting 36.0.0",
- "pallet-whitelist 35.0.0",
- "pallet-xcm 15.0.0",
- "pallet-xcm-benchmarks 15.0.0",
- "parity-scale-codec",
- "paseo-runtime-constants",
- "polkadot-parachain-primitives 13.0.0",
- "polkadot-primitives 14.0.0",
- "polkadot-runtime-common 15.0.0",
- "polkadot-runtime-parachains 15.0.4",
- "relay-common",
- "scale-info",
- "serde_json",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authority-discovery 33.0.0",
- "sp-block-builder 33.0.0",
- "sp-consensus-babe 0.39.0",
- "sp-consensus-beefy 20.0.0",
- "sp-core 34.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-genesis-builder 0.14.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-npos-elections 33.0.0",
- "sp-offchain 33.0.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 21.0.0",
- "sp-transaction-pool 33.0.0",
- "sp-version 36.0.0",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
- "substrate-wasm-builder 23.0.0",
- "xcm-runtime-apis 0.2.0",
-]
-
-[[package]]
-name = "paseo-runtime-constants"
-version = "1.0.0"
-source = "git+https://github.com/paseo-network/runtimes?tag=v1.3.4#313b81aa2b2cb076b4f99c9b2bea040a8bcf709f"
-dependencies = [
- "frame-support 36.0.1",
- "polkadot-primitives 14.0.0",
- "polkadot-runtime-common 15.0.0",
- "smallvec",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm-builder 15.0.0",
-]
 
 [[package]]
 name = "password-hash"
@@ -11974,7 +9272,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "tracing-gum",
 ]
@@ -11990,7 +9288,7 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "tracing-gum",
 ]
@@ -12009,7 +9307,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "sc-network",
  "schnellru",
@@ -12033,7 +9331,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "sc-network",
  "schnellru",
@@ -12073,9 +9371,9 @@ dependencies = [
  "sc-tracing",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-runtime 40.1.0",
+ "sp-keyring",
+ "sp-maybe-compressed-blob",
+ "sp-runtime",
  "substrate-build-script-utils",
  "thiserror 1.0.69",
 ]
@@ -12093,27 +9391,14 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "schnellru",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
  "tokio-util",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c72ee63bcf920f963cd7ac066759b0b649350c8ab3781a85a6aac87b1488f2"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12124,7 +9409,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12143,10 +9428,10 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-keystore 0.41.0",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -12159,7 +9444,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core 35.0.0",
  "sp-trie 38.0.0",
@@ -12176,12 +9461,12 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "rand_chacha",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-keystore 0.41.0",
@@ -12204,7 +9489,7 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-network",
  "sp-consensus",
  "thiserror 1.0.69",
@@ -12222,10 +9507,10 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "schnellru",
  "sp-core 35.0.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-maybe-compressed-blob",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -12248,17 +9533,17 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "rand_chacha",
  "rand_core",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-consensus",
- "sp-consensus-slots 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-consensus-slots",
+ "sp-runtime",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -12280,15 +9565,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "rand_chacha",
  "rand_core",
  "sc-keystore",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-consensus",
- "sp-consensus-slots 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-consensus-slots",
+ "sp-runtime",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -12308,7 +9593,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sp-consensus",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -12326,8 +9611,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "polkadot-statement-table",
  "schnellru",
  "sp-keystore 0.41.0",
@@ -12343,7 +9628,7 @@ dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sp-keystore 0.41.0",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -12365,9 +9650,9 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
- "sp-application-crypto 39.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "sp-application-crypto",
  "sp-keystore 0.41.0",
  "tracing-gum",
 ]
@@ -12398,7 +9683,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -12415,7 +9700,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-keystore",
  "schnellru",
  "thiserror 1.0.69",
@@ -12432,9 +9717,9 @@ dependencies = [
  "futures-timer",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -12448,7 +9733,7 @@ dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -12465,7 +9750,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "schnellru",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -12484,13 +9769,13 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives 16.0.0",
+ "polkadot-core-primitives",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "rand",
  "slotmap",
  "sp-core 35.0.0",
@@ -12511,7 +9796,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sp-keystore 0.41.0",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -12528,8 +9813,8 @@ dependencies = [
  "libc",
  "nix 0.28.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "sc-executor",
  "sc-executor-common",
  "sc-executor-wasmtime",
@@ -12552,9 +9837,9 @@ dependencies = [
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "schnellru",
- "sp-consensus-babe 0.41.0",
+ "sp-consensus-babe",
  "tracing-gum",
 ]
 
@@ -12568,7 +9853,7 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "prioritized-metered-channel",
  "sc-cli",
  "sc-service",
@@ -12591,12 +9876,12 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "polkadot-node-primitives",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "rand",
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "strum 0.26.3",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -12612,18 +9897,18 @@ dependencies = [
  "futures",
  "futures-timer",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "sc-keystore",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto 39.0.0",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-slots 0.41.0",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-runtime 40.1.0",
+ "sp-maybe-compressed-blob",
+ "sp-runtime",
  "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
@@ -12650,18 +9935,18 @@ dependencies = [
  "orchestra",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "polkadot-statement-table",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api 35.0.0",
- "sp-authority-discovery 35.0.0",
+ "sp-api",
+ "sp-authority-discovery",
  "sp-blockchain",
- "sp-consensus-babe 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-consensus-babe",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -12689,12 +9974,12 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "prioritized-metered-channel",
  "rand",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
  "thiserror 1.0.69",
@@ -12715,30 +10000,12 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-client-api",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
  "tikv-jemalloc-ctl",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-parachain-primitives"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61070d0ff28f596890def0e0d03c231860796130b2a43e293106fa86a50c9a9"
-dependencies = [
- "bounded-collections",
- "derive_more 0.99.19",
- "parity-scale-codec",
- "polkadot-core-primitives 14.0.0",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12749,40 +10016,12 @@ dependencies = [
  "bounded-collections",
  "derive_more 0.99.19",
  "parity-scale-codec",
- "polkadot-core-primitives 16.0.0",
+ "polkadot-core-primitives",
  "scale-info",
  "serde",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "polkadot-primitives"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4879609f4340138930c3c7313256941104a3ff6f7ecb2569d15223da9b35b2"
-dependencies = [
- "bitvec",
- "hex-literal",
- "log",
- "parity-scale-codec",
- "polkadot-core-primitives 14.0.0",
- "polkadot-parachain-primitives 13.0.0",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authority-discovery 33.0.0",
- "sp-consensus-slots 0.39.0",
- "sp-core 34.0.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12794,21 +10033,21 @@ dependencies = [
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives 16.0.0",
- "polkadot-parachain-primitives 15.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-authority-discovery 35.0.0",
- "sp-consensus-slots 0.41.0",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-io 39.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "thiserror 1.0.69",
 ]
@@ -12821,7 +10060,7 @@ dependencies = [
  "jsonrpsee 0.24.8",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -12835,149 +10074,68 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-beefy 23.0.0",
+ "sp-consensus-babe",
+ "sp-consensus-beefy",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fdcb41bb21c7b14d0341a9a17364ccc04ad34de05d41e7938cb03acbc11066"
-dependencies = [
- "bitvec",
- "frame-benchmarking 36.0.0",
- "frame-election-provider-support 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "libsecp256k1",
- "log",
- "pallet-asset-rate 15.0.0",
- "pallet-authorship 36.0.0",
- "pallet-babe 36.0.0",
- "pallet-balances 37.0.0",
- "pallet-broker 0.15.0",
- "pallet-election-provider-multi-phase 35.0.0",
- "pallet-fast-unstake 35.0.0",
- "pallet-identity 36.0.0",
- "pallet-session 36.0.0",
- "pallet-staking 36.0.0",
- "pallet-staking-reward-fn 22.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 35.0.0",
- "pallet-transaction-payment 36.0.0",
- "pallet-treasury 35.0.0",
- "pallet-vesting 36.0.0",
- "parity-scale-codec",
- "polkadot-primitives 14.0.0",
- "polkadot-runtime-parachains 15.0.4",
- "rustc-hex",
- "scale-info",
- "serde",
- "serde_derive",
- "slot-range-helper 14.0.0",
- "sp-api 33.0.0",
- "sp-core 34.0.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-npos-elections 33.0.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
- "staging-xcm-executor 15.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "polkadot-runtime-common"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "bitvec",
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
- "pallet-asset-rate 18.0.0",
- "pallet-authorship 39.0.0",
- "pallet-babe 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-broker 0.18.0",
- "pallet-election-provider-multi-phase 38.0.0",
- "pallet-fast-unstake 38.0.0",
- "pallet-identity 39.0.0",
- "pallet-session 39.0.0",
- "pallet-staking 39.0.1",
- "pallet-staking-reward-fn 22.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "pallet-timestamp 38.0.0",
- "pallet-transaction-payment 39.0.0",
- "pallet-treasury 38.0.0",
- "pallet-vesting 39.0.0",
+ "pallet-asset-rate",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-election-provider-multi-phase",
+ "pallet-fast-unstake",
+ "pallet-identity",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-staking-reward-fn",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "scale-info",
  "serde",
  "serde_derive",
- "slot-range-helper 16.0.0",
- "sp-api 35.0.0",
+ "slot-range-helper",
+ "sp-api",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-npos-elections 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
+ "sp-keyring",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
-]
-
-[[package]]
-name = "polkadot-runtime-constants"
-version = "1.0.0"
-source = "git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4#3b18d942c766c7f358da50608b44edbe218284a4"
-dependencies = [
- "frame-support 36.0.1",
- "polkadot-primitives 14.0.0",
- "polkadot-runtime-common 15.0.0",
- "smallvec",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm-builder 15.0.0",
-]
-
-[[package]]
-name = "polkadot-runtime-metrics"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac75b3fea8464e5681b44733ed11cf09e22ff1e956f6703b918b637bd40e7427"
-dependencies = [
- "bs58",
- "frame-benchmarking 36.0.0",
- "parity-scale-codec",
- "polkadot-primitives 14.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 17.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12986,60 +10144,10 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "bs58",
- "frame-benchmarking 39.0.0",
+ "frame-benchmarking",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "polkadot-runtime-parachains"
-version = "15.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f6a36ba61ca8f2c07b7061894f3a947d77189c66e992a2f23109eb01dfa9e0"
-dependencies = [
- "bitflags 1.3.2",
- "bitvec",
- "derive_more 0.99.19",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-authority-discovery 36.0.0",
- "pallet-authorship 36.0.0",
- "pallet-babe 36.0.0",
- "pallet-balances 37.0.0",
- "pallet-broker 0.15.0",
- "pallet-message-queue 39.0.2",
- "pallet-session 36.0.0",
- "pallet-staking 36.0.0",
- "pallet-timestamp 35.0.0",
- "pallet-vesting 36.0.0",
- "parity-scale-codec",
- "polkadot-core-primitives 14.0.0",
- "polkadot-parachain-primitives 13.0.0",
- "polkadot-primitives 14.0.0",
- "polkadot-runtime-metrics 15.0.0",
- "rand",
- "rand_chacha",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 38.0.1",
- "sp-session 34.0.0",
- "sp-staking 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-executor 15.0.0",
- "static_assertions",
- "xcm-procedural 10.0.1",
 ]
 
 [[package]]
@@ -13050,44 +10158,44 @@ dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more 0.99.19",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-authority-discovery 39.0.0",
- "pallet-authorship 39.0.0",
- "pallet-babe 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-broker 0.18.0",
- "pallet-message-queue 42.0.0",
- "pallet-mmr 39.0.0",
- "pallet-session 39.0.0",
- "pallet-staking 39.0.1",
- "pallet-timestamp 38.0.0",
- "pallet-vesting 39.0.0",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-message-queue",
+ "pallet-mmr",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "pallet-vesting",
  "parity-scale-codec",
- "polkadot-core-primitives 16.0.0",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-metrics 18.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-metrics",
  "rand",
  "rand_chacha",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-io 39.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -13097,32 +10205,32 @@ version = "0.8.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-benchmarking 39.0.0",
- "frame-executive 39.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-system-benchmarking 39.0.0",
- "frame-system-rpc-runtime-api 35.0.0",
- "frame-try-runtime 0.45.0",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-block-builder 35.0.0",
- "sp-consensus-aura 0.41.0",
- "sp-consensus-grandpa 22.0.0",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-grandpa",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
  "sp-storage 22.0.0",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
+ "sp-transaction-pool",
+ "sp-version",
 ]
 
 [[package]]
@@ -13131,18 +10239,18 @@ version = "22.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
- "frame-benchmarking 39.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-system 39.1.0",
- "frame-system-rpc-runtime-api 35.0.0",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
  "futures",
  "is_executable",
  "kvdb",
  "kvdb-rocksdb",
  "log",
  "mmr-gadget",
- "pallet-transaction-payment 39.0.0",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13151,7 +10259,7 @@ dependencies = [
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 16.0.0",
+ "polkadot-core-primitives",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -13177,9 +10285,9 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "polkadot-rpc",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
  "sc-authority-discovery",
@@ -13204,33 +10312,33 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api 35.0.0",
- "sp-authority-discovery 35.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-beefy 23.0.0",
- "sp-consensus-grandpa 22.0.0",
+ "sp-consensus-babe",
+ "sp-consensus-beefy",
+ "sp-consensus-grandpa",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-timestamp 35.0.0",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
+ "sp-keyring",
+ "sp-mmr-primitives",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-timestamp",
+ "sp-transaction-pool",
+ "sp-version",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tracing-gum",
  "westend-runtime",
- "xcm-runtime-apis 0.5.0",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -13249,9 +10357,9 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sp-keystore 0.41.0",
- "sp-staking 37.0.0",
+ "sp-staking",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -13262,7 +10370,7 @@ version = "17.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "sp-core 35.0.0",
  "tracing-gum",
 ]
@@ -13511,11 +10619,11 @@ version = "0.1.0"
 dependencies = [
  "contract-build",
  "env_logger 0.11.6",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-assets 41.0.0",
- "pallet-balances 40.0.0",
+ "pallet-assets",
+ "pallet-balances",
  "pallet-contracts",
  "parity-scale-codec",
  "pop-api",
@@ -13523,7 +10631,7 @@ dependencies = [
  "pop-runtime-devnet",
  "pop-runtime-testnet",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13532,19 +10640,19 @@ version = "0.1.0"
 dependencies = [
  "contract-build",
  "env_logger 0.11.6",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 40.0.0",
+ "pallet-balances",
  "pallet-contracts",
- "pallet-timestamp 38.0.0",
+ "pallet-timestamp",
  "parity-scale-codec",
  "rand",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
 
@@ -13560,12 +10668,12 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-proposer",
  "cumulus-client-service",
- "cumulus-primitives-aura 0.16.0",
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-parachain-inherent 0.17.0",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
  "docify",
- "frame-benchmarking 39.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures",
  "ismp-parachain",
@@ -13575,11 +10683,11 @@ dependencies = [
  "log",
  "pallet-ismp-rpc",
  "pallet-ismp-runtime-api",
- "pallet-multisig 39.0.0",
+ "pallet-multisig",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "pop-runtime-common",
  "pop-runtime-devnet",
  "pop-runtime-mainnet",
@@ -13602,20 +10710,20 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
- "sp-consensus-aura 0.41.0",
+ "sp-consensus-aura",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
+ "sp-genesis-builder",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
+ "sp-keyring",
  "sp-keystore 0.41.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-timestamp 35.0.0",
- "sp-transaction-pool 35.0.0",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-timestamp",
+ "sp-transaction-pool",
  "staging-xcm 15.0.1",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
@@ -13636,12 +10744,12 @@ name = "pop-runtime-common"
 version = "0.0.0"
 dependencies = [
  "docify",
- "frame-support 39.0.0",
- "parachains-common 19.0.0",
+ "frame-support",
+ "parachains-common",
  "parity-scale-codec",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "scale-info",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13649,26 +10757,26 @@ name = "pop-runtime-devnet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cumulus-pallet-aura-ext 0.18.0",
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-session-benchmarking 20.0.0",
- "cumulus-pallet-xcm 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-aura 0.16.0",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-pallet-aura-ext",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-session-benchmarking",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
  "cumulus-primitives-storage-weight-reclaim",
- "cumulus-primitives-utility 0.18.0",
+ "cumulus-primitives-utility",
  "docify",
  "enumflags2",
  "env_logger 0.11.6",
- "frame-benchmarking 39.0.0",
- "frame-executive 39.0.0",
- "frame-metadata-hash-extension 0.7.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-system-benchmarking 39.0.0",
- "frame-system-rpc-runtime-api 35.0.0",
- "frame-try-runtime 0.45.0",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex",
  "hex-literal",
  "ismp",
@@ -13676,209 +10784,209 @@ dependencies = [
  "ismp-parachain-runtime-api",
  "log",
  "pallet-api",
- "pallet-assets 41.0.0",
- "pallet-aura 38.0.0",
- "pallet-authorship 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-collator-selection 20.0.0",
+ "pallet-assets",
+ "pallet-aura",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
  "pallet-contracts",
  "pallet-ismp",
  "pallet-ismp-runtime-api",
- "pallet-message-queue 42.0.0",
- "pallet-multisig 39.0.0",
+ "pallet-message-queue",
+ "pallet-multisig",
  "pallet-nft-fractionalization",
  "pallet-nfts 31.0.0",
- "pallet-nfts-runtime-api 25.0.0",
- "pallet-preimage 39.0.0",
- "pallet-proxy 39.0.0",
+ "pallet-nfts-runtime-api",
+ "pallet-preimage",
+ "pallet-proxy",
  "pallet-revive",
- "pallet-scheduler 40.0.0",
- "pallet-session 39.0.0",
- "pallet-sudo 39.0.0",
- "pallet-timestamp 38.0.0",
- "pallet-transaction-payment 39.0.0",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
- "pallet-utility 39.0.0",
- "pallet-xcm 18.0.0",
- "parachains-common 19.0.0",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-utility",
+ "pallet-xcm",
+ "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-runtime-common 18.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-common",
  "pop-chain-extension",
  "pop-primitives",
  "pop-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
- "sp-consensus-aura 0.41.0",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
+ "sp-mmr-primitives",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
- "staging-parachain-info 0.18.0",
+ "sp-transaction-pool",
+ "sp-version",
+ "staging-parachain-info",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "pop-runtime-mainnet"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-aura-ext 0.18.0",
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-session-benchmarking 20.0.0",
- "cumulus-pallet-xcm 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-aura 0.16.0",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-pallet-aura-ext",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-session-benchmarking",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
  "cumulus-primitives-storage-weight-reclaim",
- "cumulus-primitives-utility 0.18.0",
+ "cumulus-primitives-utility",
  "docify",
  "enumflags2",
  "env_logger 0.11.6",
- "frame-benchmarking 39.0.0",
- "frame-executive 39.0.0",
- "frame-metadata-hash-extension 0.7.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-system-benchmarking 39.0.0",
- "frame-system-rpc-runtime-api 35.0.0",
- "frame-try-runtime 0.45.0",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex",
  "log",
- "pallet-aura 38.0.0",
- "pallet-authorship 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-collator-selection 20.0.0",
+ "pallet-aura",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
  "pallet-collective",
- "pallet-message-queue 42.0.0",
+ "pallet-message-queue",
  "pallet-motion",
- "pallet-multisig 39.0.0",
- "pallet-preimage 39.0.0",
- "pallet-proxy 39.0.0",
+ "pallet-multisig",
+ "pallet-preimage",
+ "pallet-proxy",
  "pallet-revive",
- "pallet-scheduler 40.0.0",
- "pallet-session 39.0.0",
- "pallet-sudo 39.0.0",
- "pallet-timestamp 38.0.0",
- "pallet-transaction-payment 39.0.0",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
- "pallet-treasury 38.0.0",
- "pallet-utility 39.0.0",
- "pallet-xcm 18.0.0",
- "parachains-common 19.0.0",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-utility",
+ "pallet-xcm",
+ "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-runtime-common 18.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-common",
  "pop-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
- "sp-consensus-aura 0.41.0",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
- "staging-parachain-info 0.18.0",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-transaction-pool",
+ "sp-version",
+ "staging-parachain-info",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
- "xcm-runtime-apis 0.5.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "substrate-wasm-builder",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "pop-runtime-testnet"
 version = "0.4.2"
 dependencies = [
- "cumulus-pallet-aura-ext 0.18.0",
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-session-benchmarking 20.0.0",
- "cumulus-pallet-xcm 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-aura 0.16.0",
- "cumulus-primitives-core 0.17.0",
+ "cumulus-pallet-aura-ext",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-session-benchmarking",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
  "cumulus-primitives-storage-weight-reclaim",
- "cumulus-primitives-utility 0.18.0",
+ "cumulus-primitives-utility",
  "docify",
  "enumflags2",
  "env_logger 0.11.6",
- "frame-benchmarking 39.0.0",
- "frame-executive 39.0.0",
- "frame-metadata-hash-extension 0.7.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-system-benchmarking 39.0.0",
- "frame-system-rpc-runtime-api 35.0.0",
- "frame-try-runtime 0.45.0",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex",
  "hex-literal",
  "log",
  "pallet-api",
- "pallet-assets 41.0.0",
- "pallet-aura 38.0.0",
- "pallet-authorship 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-collator-selection 20.0.0",
+ "pallet-assets",
+ "pallet-aura",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
  "pallet-contracts",
- "pallet-message-queue 42.0.0",
- "pallet-multisig 39.0.0",
+ "pallet-message-queue",
+ "pallet-multisig",
  "pallet-nft-fractionalization",
  "pallet-nfts 31.0.0",
- "pallet-nfts-runtime-api 25.0.0",
- "pallet-preimage 39.0.0",
- "pallet-proxy 39.0.0",
- "pallet-scheduler 40.0.0",
- "pallet-session 39.0.0",
- "pallet-sudo 39.0.0",
- "pallet-timestamp 38.0.0",
- "pallet-transaction-payment 39.0.0",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
- "pallet-utility 39.0.0",
- "pallet-xcm 18.0.0",
- "parachains-common 19.0.0",
+ "pallet-nfts-runtime-api",
+ "pallet-preimage",
+ "pallet-proxy",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-utility",
+ "pallet-xcm",
+ "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-runtime-common 18.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-common",
  "pop-chain-extension",
  "pop-primitives",
  "pop-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
- "sp-consensus-aura 0.41.0",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
- "staging-parachain-info 0.18.0",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-transaction-pool",
+ "sp-version",
+ "staging-parachain-info",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -13960,8 +11068,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec 0.6.0",
- "impl-num-traits 0.1.2",
- "impl-rlp 0.3.0",
  "impl-serde 0.4.0",
  "scale-info",
  "uint 0.9.5",
@@ -13975,8 +11081,8 @@ checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
  "impl-codec 0.7.0",
- "impl-num-traits 0.2.0",
- "impl-rlp 0.4.0",
+ "impl-num-traits",
+ "impl-rlp",
  "impl-serde 0.5.0",
  "scale-info",
  "uint 0.10.0",
@@ -14567,19 +11673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "relay-common"
-version = "1.0.0"
-source = "git+https://github.com/paseo-network/runtimes?tag=v1.3.4#313b81aa2b2cb076b4f99c9b2bea040a8bcf709f"
-dependencies = [
- "pallet-staking-reward-fn 22.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec",
- "polkadot-primitives 14.0.0",
- "scale-info",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14646,16 +11739,6 @@ checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
-name = "rlp"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
@@ -14679,101 +11762,101 @@ name = "rococo-runtime"
 version = "21.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "binary-merkle-tree 16.0.0",
+ "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 39.0.0",
- "frame-executive 39.0.0",
- "frame-metadata-hash-extension 0.7.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-system-benchmarking 39.0.0",
- "frame-system-rpc-runtime-api 35.0.0",
- "frame-try-runtime 0.45.0",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal",
  "log",
- "pallet-asset-rate 18.0.0",
- "pallet-authority-discovery 39.0.0",
- "pallet-authorship 39.0.0",
- "pallet-babe 39.0.0",
- "pallet-balances 40.0.0",
- "pallet-beefy 40.0.0",
- "pallet-beefy-mmr 40.0.0",
- "pallet-bounties 38.0.1",
- "pallet-child-bounties 38.0.0",
+ "pallet-asset-rate",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-beefy",
+ "pallet-beefy-mmr",
+ "pallet-bounties",
+ "pallet-child-bounties",
  "pallet-collective",
- "pallet-conviction-voting 39.0.0",
+ "pallet-conviction-voting",
  "pallet-democracy",
  "pallet-elections-phragmen",
- "pallet-grandpa 39.0.0",
- "pallet-identity 39.0.0",
- "pallet-indices 39.0.0",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-indices",
  "pallet-membership",
- "pallet-message-queue 42.0.0",
+ "pallet-message-queue",
  "pallet-migrations",
- "pallet-mmr 39.0.0",
- "pallet-multisig 39.0.0",
+ "pallet-mmr",
+ "pallet-multisig",
  "pallet-nis",
- "pallet-offences 38.0.0",
- "pallet-parameters 0.10.0",
- "pallet-preimage 39.0.0",
- "pallet-proxy 39.0.0",
+ "pallet-offences",
+ "pallet-parameters",
+ "pallet-preimage",
+ "pallet-proxy",
  "pallet-ranked-collective",
  "pallet-recovery",
- "pallet-referenda 39.0.0",
+ "pallet-referenda",
  "pallet-root-testing",
- "pallet-scheduler 40.0.0",
- "pallet-session 39.0.0",
+ "pallet-scheduler",
+ "pallet-session",
  "pallet-society",
- "pallet-staking 39.0.1",
- "pallet-state-trie-migration 43.0.0",
- "pallet-sudo 39.0.0",
- "pallet-timestamp 38.0.0",
+ "pallet-staking",
+ "pallet-state-trie-migration",
+ "pallet-sudo",
+ "pallet-timestamp",
  "pallet-tips",
- "pallet-transaction-payment 39.0.0",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
- "pallet-treasury 38.0.0",
- "pallet-utility 39.0.0",
- "pallet-vesting 39.0.0",
- "pallet-whitelist 38.0.0",
- "pallet-xcm 18.0.0",
- "pallet-xcm-benchmarks 18.0.0",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-utility",
+ "pallet-vesting",
+ "pallet-whitelist",
+ "pallet-xcm",
+ "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-common 18.0.0",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "rococo-runtime-constants",
  "scale-info",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-authority-discovery 35.0.0",
- "sp-block-builder 35.0.0",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-beefy 23.0.0",
- "sp-consensus-grandpa 22.0.0",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-consensus-babe",
+ "sp-consensus-beefy",
+ "sp-consensus-grandpa",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
+ "sp-keyring",
+ "sp-mmr-primitives",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
  "sp-storage 22.0.0",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
+ "sp-transaction-pool",
+ "sp-version",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
- "substrate-wasm-builder 25.0.0",
- "xcm-runtime-apis 0.5.0",
+ "substrate-wasm-builder",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -14781,15 +11864,15 @@ name = "rococo-runtime-constants"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-common 18.0.0",
+ "frame-support",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -15175,12 +12258,12 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-types",
- "sp-api 35.0.0",
- "sp-authority-discovery 35.0.0",
+ "sp-api",
+ "sp-authority-discovery",
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15198,12 +12281,12 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -15213,12 +12296,12 @@ version = "0.43.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "parity-scale-codec",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-trie 38.0.0",
 ]
 
@@ -15242,9 +12325,9 @@ dependencies = [
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-genesis-builder 0.16.0",
+ "sp-genesis-builder",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
 ]
@@ -15293,11 +12376,11 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-keyring 40.0.0",
+ "sp-keyring",
  "sp-keystore 0.41.0",
  "sp-panic-handler 13.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-runtime 40.1.0",
- "sp-version 38.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -15315,13 +12398,13 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core 35.0.0",
  "sp-database",
  "sp-externalities 0.30.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-statement-store",
  "sp-storage 22.0.0",
@@ -15350,7 +12433,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-database",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-trie 38.0.0",
 ]
@@ -15369,11 +12452,11 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -15393,17 +12476,17 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.41.0",
- "sp-consensus-slots 0.41.0",
+ "sp-consensus-aura",
+ "sp-consensus-slots",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15428,18 +12511,18 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-slots 0.41.0",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-inherents 35.0.0",
+ "sp-inherents",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15455,14 +12538,14 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.41.0",
+ "sp-consensus-babe",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -15486,16 +12569,16 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "sc-utils",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-beefy 23.0.0",
+ "sp-consensus-beefy",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -15515,10 +12598,10 @@ dependencies = [
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
- "sp-application-crypto 39.0.0",
- "sp-consensus-beefy 23.0.0",
+ "sp-application-crypto",
+ "sp-consensus-beefy",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -15532,7 +12615,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15540,7 +12623,7 @@ name = "sc-consensus-grandpa"
 version = "0.33.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "array-bytes",
  "async-trait",
  "dyn-clone",
@@ -15565,16 +12648,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-grandpa 22.0.0",
+ "sp-consensus-grandpa",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15595,7 +12678,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -15615,10 +12698,10 @@ dependencies = [
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.41.0",
+ "sp-consensus-slots",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
 ]
 
@@ -15633,14 +12716,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0",
  "sp-io 39.0.0",
  "sp-panic-handler 13.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-runtime-interface 29.0.0",
  "sp-trie 38.0.0",
- "sp-version 38.0.0",
+ "sp-version",
  "sp-wasm-interface 21.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "tracing",
 ]
@@ -15652,7 +12735,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-maybe-compressed-blob",
  "sp-wasm-interface 21.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "thiserror 1.0.69",
  "wasm-instrument",
@@ -15701,7 +12784,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15712,7 +12795,7 @@ dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
  "thiserror 1.0.69",
@@ -15738,12 +12821,12 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
  "sp-mixnet",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -15787,7 +12870,7 @@ dependencies = [
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -15812,8 +12895,8 @@ dependencies = [
  "sc-consensus",
  "sc-network-types",
  "sp-consensus",
- "sp-consensus-grandpa 22.0.0",
- "sp-runtime 40.1.0",
+ "sp-consensus-grandpa",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15821,7 +12904,7 @@ name = "sc-network-gossip"
 version = "0.48.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "futures",
  "futures-timer",
  "log",
@@ -15830,7 +12913,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -15852,7 +12935,7 @@ dependencies = [
  "sc-network-types",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -15883,9 +12966,9 @@ dependencies = [
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-grandpa 22.0.0",
+ "sp-consensus-grandpa",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -15907,7 +12990,7 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -15955,12 +13038,12 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0",
  "sp-keystore 0.41.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-offchain",
+ "sp-runtime",
  "threadpool",
  "tracing",
 ]
@@ -15993,16 +13076,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
- "sp-offchain 35.0.0",
+ "sp-offchain",
  "sp-rpc",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
+ "sp-runtime",
+ "sp-session",
  "sp-statement-store",
- "sp-version 38.0.0",
+ "sp-version",
  "tokio",
 ]
 
@@ -16021,8 +13104,8 @@ dependencies = [
  "serde_json",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 40.1.0",
- "sp-version 38.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror 1.0.69",
 ]
 
@@ -16071,12 +13154,12 @@ dependencies = [
  "sc-transaction-pool-api",
  "schnellru",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 40.1.0",
- "sp-version 38.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -16123,20 +13206,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
+ "sp-runtime",
+ "sp-session",
  "sp-state-machine 0.44.0",
  "sp-storage 22.0.0",
- "sp-transaction-pool 35.0.0",
+ "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie 38.0.0",
- "sp-version 38.0.0",
+ "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -16185,7 +13268,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -16246,11 +13329,11 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "thiserror 1.0.69",
  "tracing",
@@ -16287,13 +13370,13 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-transaction-pool 35.0.0",
+ "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -16312,7 +13395,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -16578,7 +13661,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -16789,15 +13872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -17092,26 +14166,13 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d67aa9b1ccfd746c8529754c4ce06445b1d48e189567402ef856340a3a6b14"
-dependencies = [
- "enumn",
- "parity-scale-codec",
- "paste",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "slot-range-helper"
 version = "16.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -17368,203 +14429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snowbridge-amcl"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460a9ed63cdf03c1b9847e8a12a5f5ba19c4efd5869e4a737e05be25d7c427e5"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "snowbridge-beacon-primitives"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ad61e3ab1c48d4c8060c7ef8571c5b6007df26687e8dbfdb6c857d840cfd2c"
-dependencies = [
- "byte-slice-cast",
- "frame-support 36.0.1",
- "hex",
- "parity-scale-codec",
- "rlp 0.5.2",
- "scale-info",
- "serde",
- "snowbridge-ethereum 0.8.0",
- "snowbridge-milagro-bls",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ssz_rs",
- "ssz_rs_derive",
-]
-
-[[package]]
-name = "snowbridge-beacon-primitives"
-version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "byte-slice-cast",
- "frame-support 39.0.0",
- "hex",
- "parity-scale-codec",
- "rlp 0.6.1",
- "scale-info",
- "serde",
- "snowbridge-ethereum 0.11.0",
- "snowbridge-milagro-bls",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "ssz_rs",
- "ssz_rs_derive",
-]
-
-[[package]]
-name = "snowbridge-core"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668cd71582305168ed51cb0357a4b4ea814c68c7db3898a9ba4d492f712c54e1"
-dependencies = [
- "ethabi-decode 1.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "hex-literal",
- "parity-scale-codec",
- "polkadot-parachain-primitives 13.0.0",
- "scale-info",
- "serde",
- "snowbridge-beacon-primitives 0.8.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-builder 15.0.0",
-]
-
-[[package]]
-name = "snowbridge-core"
-version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "ethabi-decode 2.0.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "hex-literal",
- "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "scale-info",
- "serde",
- "snowbridge-beacon-primitives 0.12.0",
- "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
-]
-
-[[package]]
-name = "snowbridge-ethereum"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef1f6f60f6c8cc3cdb2a829d7452de946d8707f63f70c6f714d1c52cbc0fc17"
-dependencies = [
- "ethabi-decode 1.0.0",
- "ethbloom 0.13.0",
- "ethereum-types 0.14.1",
- "hex-literal",
- "parity-bytes",
- "parity-scale-codec",
- "rlp 0.5.2",
- "scale-info",
- "serde",
- "serde-big-array",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "snowbridge-ethereum"
-version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "ethabi-decode 2.0.0",
- "ethbloom 0.14.1",
- "ethereum-types 0.15.1",
- "hex-literal",
- "parity-bytes",
- "parity-scale-codec",
- "rlp 0.6.1",
- "scale-info",
- "serde",
- "serde-big-array",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
-]
-
-[[package]]
-name = "snowbridge-milagro-bls"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026aa8638f690a53e3f7676024b9e913b1cab0111d1b7b92669d40a188f9d7e6"
-dependencies = [
- "hex",
- "lazy_static",
- "parity-scale-codec",
- "rand",
- "scale-info",
- "snowbridge-amcl",
- "zeroize",
-]
-
-[[package]]
-name = "snowbridge-router-primitives"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8e6707ced1308d763117bfe68f85e3f22fcdca7987b32e438c0485570f6ac7"
-dependencies = [
- "frame-support 36.0.1",
- "hex-literal",
- "log",
- "parity-scale-codec",
- "scale-info",
- "snowbridge-core 0.8.0",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-executor 15.0.0",
-]
-
-[[package]]
-name = "snowbridge-router-primitives"
-version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "frame-support 39.0.0",
- "hex-literal",
- "log",
- "parity-scale-codec",
- "scale-info",
- "snowbridge-core 0.12.0",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
-]
-
-[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17617,29 +14481,6 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e43fbf034e9dbaa8ffc6a238a22808777eb38c580f66fc6736d8511631789e"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 20.0.0",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-metadata-ir 0.7.0",
- "sp-runtime 38.0.1",
- "sp-runtime-interface 28.0.0",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
- "sp-version 36.0.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-api"
 version = "35.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
@@ -17648,31 +14489,16 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 21.0.0",
+ "sp-api-proc-macro",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0",
- "sp-metadata-ir 0.8.0",
- "sp-runtime 40.1.0",
+ "sp-metadata-ir",
+ "sp-runtime",
  "sp-runtime-interface 29.0.0",
  "sp-state-machine 0.44.0",
  "sp-trie 38.0.0",
- "sp-version 38.0.0",
+ "sp-version",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9aadf9e97e694f0e343978aa632938c5de309cbcc8afed4136cb71596737278"
-dependencies = [
- "Inflector",
- "blake2 0.10.6",
- "expander",
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -17687,20 +14513,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d96d1fc0f1c741bbcbd0dd5470eff7b66f011708cc1942b088ebf0d4efb3d93"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -17747,38 +14559,14 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4a1e45abc3277f18484ee0b0f9808e4206eb696ad38500c892c72f33480d69"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-runtime 38.0.1",
-]
-
-[[package]]
-name = "sp-authority-discovery"
 version = "35.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "sp-block-builder"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf199dc4f9f77abd3fd91c409759118159ce6ffcd8bc90b229b684ccc8c981f"
-dependencies = [
- "sp-api 33.0.0",
- "sp-inherents 33.0.0",
- "sp-runtime 38.0.1",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -17786,9 +14574,9 @@ name = "sp-block-builder"
 version = "35.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "sp-api 35.0.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -17800,11 +14588,11 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core 35.0.0",
  "sp-database",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "thiserror 1.0.69",
  "tracing",
@@ -17819,62 +14607,26 @@ dependencies = [
  "futures",
  "log",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ebb90bf00f331b898eb729a1f707251846c1d5582d7467f083884799a69b89"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-consensus-slots 0.39.0",
- "sp-inherents 33.0.0",
- "sp-runtime 38.0.1",
- "sp-timestamp 33.0.0",
-]
-
-[[package]]
-name = "sp-consensus-aura"
 version = "0.41.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
- "sp-consensus-slots 0.41.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
- "sp-timestamp 35.0.0",
-]
-
-[[package]]
-name = "sp-consensus-babe"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa2de4c7100a3279658d8dd4affd8f92487528deae5cb4b40322717b9175ed5"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-consensus-slots 0.39.0",
- "sp-core 34.0.0",
- "sp-inherents 33.0.0",
- "sp-runtime 38.0.1",
- "sp-timestamp 33.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -17886,34 +14638,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
- "sp-consensus-slots 0.41.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
- "sp-timestamp 35.0.0",
-]
-
-[[package]]
-name = "sp-consensus-beefy"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b277bc109da8e1c3768d3a046e1cd1ab687aabac821c976c5f510deb6f0bc8d3"
-dependencies = [
- "lazy_static",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-core 34.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 37.0.0",
- "sp-keystore 0.40.0",
- "sp-mmr-primitives 33.0.0",
- "sp-runtime 38.0.1",
- "strum 0.26.3",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -17924,34 +14655,16 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-io 39.0.0",
  "sp-keystore 0.41.0",
- "sp-mmr-primitives 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-mmr-primitives",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "sp-consensus-grandpa"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dd06bf366c60f69411668b26d6ab3c55120aa6d423e6af0373ec23d8957300"
-dependencies = [
- "finality-grandpa",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -17964,23 +14677,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "sp-consensus-slots"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ca60d713f8ddb03bbebcc755d5e6463fdc0b6259fabfc4221b20a5f1e428fd"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-timestamp 33.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -17991,7 +14692,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-timestamp 35.0.0",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -18117,17 +14818,6 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
-dependencies = [
- "quote",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "sp-crypto-hashing-proc-macro"
-version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "quote",
@@ -18188,41 +14878,14 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd065854d96fd81521c103d0aaa287d4f08b9b15c9fae2a3bfb208b0812bf44"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
-]
-
-[[package]]
-name = "sp-genesis-builder"
 version = "0.16.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53407ba38ec22ca4a16381722c4bd0b559a0428bc1713079b0d5163ada63186a"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "thiserror 1.0.69",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -18234,35 +14897,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-io"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5036cad2e48d41f5caf6785226c8be1a7db15bec14a9fd7aa6cca84f34cf689f"
-dependencies = [
- "bytes",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "rustversion",
- "secp256k1 0.28.2",
- "sp-core 34.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.29.0",
- "sp-keystore 0.40.0",
- "sp-runtime-interface 28.0.0",
- "sp-state-machine 0.42.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 17.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -18320,22 +14956,11 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03536e1ff3ec2bd8181eeaa26c0d682ebdcbd01548a055cf591077188b8c3f0"
-dependencies = [
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "sp-keyring"
 version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "strum 0.26.3",
 ]
 
@@ -18365,31 +14990,10 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c768c11afbe698a090386876911da4236af199cd38a5866748df4d8628aeff"
-dependencies = [
- "thiserror 1.0.69",
- "zstd 0.12.4",
-]
-
-[[package]]
-name = "sp-maybe-compressed-blob"
-version = "11.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
-]
-
-[[package]]
-name = "sp-metadata-ir"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a616fa51350b35326682a472ee8e6ba742fdacb18babac38ecd46b3e05ead869"
-dependencies = [
- "frame-metadata 16.0.0",
- "parity-scale-codec",
- "scale-info",
 ]
 
 [[package]]
@@ -18409,26 +15013,8 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de88
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
-]
-
-[[package]]
-name = "sp-mmr-primitives"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47412a2d2e988430d5f59d7fec1473f229e1ef5ce24c1ea4f601b4b3679cac52"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-ckb-merkle-mountain-range",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-core 34.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 38.0.1",
- "thiserror 1.0.69",
+ "sp-api",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -18441,25 +15027,11 @@ dependencies = [
  "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
  "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-npos-elections"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0c51a7b60cd663f2661e6949069eb316b092f22c239691d5272a4d0cfca0fb"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
 ]
 
 [[package]]
@@ -18472,18 +15044,7 @@ dependencies = [
  "serde",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "sp-offchain"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe721c367760bddf10fcfa24fb48edd64c442f71db971f043c8ac73f51aa6e9"
-dependencies = [
- "sp-api 33.0.0",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -18491,9 +15052,9 @@ name = "sp-offchain"
 version = "35.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -18527,37 +15088,10 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "38.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5273900f0b0bef48b2e1ff9c4fb5e188b8168ee5891418a427f4be2af92ee40f"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 37.0.0",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
-]
-
-[[package]]
-name = "sp-runtime"
 version = "40.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "binary-merkle-tree 16.0.0",
+ "binary-merkle-tree",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -18570,7 +15104,7 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 39.0.0",
+ "sp-application-crypto",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
@@ -18649,45 +15183,16 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4daf2e40ffc7e7e8de08efb860eb9534faf614a49c53dc282f430faedb4aed13"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
-]
-
-[[package]]
-name = "sp-session"
 version = "37.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
- "sp-staking 37.0.0",
-]
-
-[[package]]
-name = "sp-staking"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0b7abfe66c07a3b6eb99e1286dfa9b6f3b057b0e986e7da2ccbf707f6c781a"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -18700,28 +15205,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211e528aa6e902261a343f7b40840aa3d66fe4ad3aadbd04a035f10baf96dbc5"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand",
- "smallvec",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-panic-handler 13.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 36.0.0",
- "thiserror 1.0.69",
- "tracing",
- "trie-db",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -18778,12 +15262,12 @@ dependencies = [
  "rand",
  "scale-info",
  "sha2 0.10.8",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-externalities 0.30.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-runtime-interface 29.0.0",
  "thiserror 1.0.69",
  "x25519-dalek",
@@ -18827,26 +15311,13 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78becf144a76f6fd108dfe94a90e20a185b38c0b310dc5482328196143c8266b"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "sp-inherents 33.0.0",
- "sp-runtime 38.0.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-timestamp"
 version = "35.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -18875,21 +15346,11 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c9d1604aadc15b70e95f4388d0b1aa380215520b7ddfd372531a6d8262269c"
-dependencies = [
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
-]
-
-[[package]]
-name = "sp-transaction-pool"
 version = "35.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "sp-api 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -18901,33 +15362,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 35.0.0",
- "sp-inherents 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-trie 38.0.0",
-]
-
-[[package]]
-name = "sp-trie"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d717c0f465f5371569e6fdc25b6f32d47c15d6e4c92b3b779e1c9b18b951d"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand",
- "scale-info",
- "schnellru",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "thiserror 1.0.69",
- "tracing",
- "trie-db",
- "trie-root",
 ]
 
 [[package]]
@@ -18936,7 +15373,7 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6282aef9f4b6ecd95a67a45bcdb67a71f4a4155c09a53c10add4ffe823db18cd"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "hash-db",
  "lazy_static",
  "memory-db",
@@ -18959,7 +15396,7 @@ name = "sp-trie"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "hash-db",
  "memory-db",
  "nohash-hasher",
@@ -18978,24 +15415,6 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bccf96fefae339dee7c4453f91be64eb28cce4c2fe82130445cf096b18b2c081"
-dependencies = [
- "impl-serde 0.4.0",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version-proc-macro 14.0.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-version"
 version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
@@ -19004,23 +15423,11 @@ dependencies = [
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-runtime 40.1.0",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-version-proc-macro 15.0.0",
+ "sp-version-proc-macro",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-version-proc-macro"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aee8f6730641a65fcf0c8f9b1e448af4b3bb083d08058b47528188bccc7b7a7"
-dependencies = [
- "parity-scale-codec",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -19135,29 +15542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_rs"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057291e5631f280978fa9c8009390663ca4613359fc1318e36a8c24c392f6d1f"
-dependencies = [
- "bitvec",
- "num-bigint",
- "sha2 0.9.9",
- "ssz_rs_derive",
-]
-
-[[package]]
-name = "ssz_rs_derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07d54c4d01a1713eb363b55ba51595da15f6f1211435b71466460da022aa140"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19165,30 +15549,15 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd00d586b0dac4f42736bdd0ad52213a891b240e011ea82b38938263dd821c25"
-dependencies = [
- "cumulus-primitives-core 0.14.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "staging-parachain-info"
 version = "0.18.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -19212,25 +15581,6 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "14.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f9bbb4905116e1ba08efe2264c046ac4d6a42dcfcb402705119068f5ac3671"
-dependencies = [
- "array-bytes",
- "bounded-collections",
- "derivative",
- "environmental",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xcm-procedural 10.0.1",
-]
-
-[[package]]
-name = "staging-xcm"
 version = "15.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
@@ -19238,83 +15588,38 @@ dependencies = [
  "bounded-collections",
  "derivative",
  "environmental",
- "frame-support 39.0.0",
+ "frame-support",
  "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "xcm-procedural 11.0.0",
 ]
 
 [[package]]
 name = "staging-xcm-builder"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847fa2afe1bed2751eaabf7b91fa4043037947f17653d7cc59ea202cc44c6bb8"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-transaction-payment 36.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 13.0.0",
- "scale-info",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-executor 15.0.0",
-]
-
-[[package]]
-name = "staging-xcm-builder"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "frame-system 39.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-asset-conversion 21.0.0",
- "pallet-transaction-payment 39.0.0",
+ "pallet-asset-conversion",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
+ "polkadot-parachain-primitives",
  "scale-info",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
-]
-
-[[package]]
-name = "staging-xcm-executor"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b98d8219449eaf02e71a7edf1a14b14d4c713dd01d9df66fde1ce30dba4d6d"
-dependencies = [
- "environmental",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 34.0.0",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -19323,15 +15628,15 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "environmental",
- "frame-benchmarking 39.0.0",
- "frame-support 39.0.0",
+ "frame-benchmarking",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
  "tracing",
@@ -19471,18 +15776,18 @@ version = "42.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "docify",
- "frame-system-rpc-runtime-api 35.0.0",
+ "frame-system-rpc-runtime-api",
  "futures",
  "jsonrpsee 0.24.8",
  "log",
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api 35.0.0",
- "sp-block-builder 35.0.0",
+ "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -19504,7 +15809,7 @@ name = "substrate-state-machine"
 version = "1.15.3"
 source = "git+https://github.com/r0gue-io/ismp?branch=polkadot-stable2412#144c98de434ebd6732283b0585c1942c64577873"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support",
  "hash-db",
  "ismp",
  "pallet-ismp",
@@ -19512,9 +15817,9 @@ dependencies = [
  "primitive-types 0.13.1",
  "scale-info",
  "serde",
- "sp-consensus-aura 0.41.0",
- "sp-consensus-babe 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-runtime",
  "sp-trie 38.0.0",
 ]
 
@@ -19529,30 +15834,10 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-state-machine 0.44.0",
  "sp-trie 38.0.0",
  "trie-db",
-]
-
-[[package]]
-name = "substrate-wasm-builder"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc993ad871b63fbba60362f3ea86583f5e7e1256e8fdcb3b5b249c9ead354bf"
-dependencies = [
- "build-helper",
- "cargo_metadata 0.15.4",
- "console",
- "filetime",
- "parity-wasm",
- "polkavm-linker 0.9.2",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "strum 0.26.3",
- "tempfile",
- "toml 0.8.19",
- "walkdir",
- "wasm-opt",
 ]
 
 [[package]]
@@ -19575,9 +15860,9 @@ dependencies = [
  "shlex",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
+ "sp-maybe-compressed-blob",
  "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-version 38.0.0",
+ "sp-version",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.19",
@@ -19823,41 +16108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-parachains-constants"
-version = "1.0.0"
-source = "git+https://github.com/paseo-network/runtimes?tag=v1.3.4#313b81aa2b2cb076b4f99c9b2bea040a8bcf709f"
-dependencies = [
- "frame-support 36.0.1",
- "parachains-common 15.0.0",
- "paseo-runtime-constants",
- "polkadot-core-primitives 14.0.0",
- "polkadot-primitives 14.0.0",
- "smallvec",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
-]
-
-[[package]]
-name = "system-parachains-constants"
-version = "1.0.0"
-source = "git+https://github.com/polkadot-fellows/runtimes?tag=v1.3.4#3b18d942c766c7f358da50608b44edbe218284a4"
-dependencies = [
- "frame-support 36.0.1",
- "kusama-runtime-constants",
- "parachains-common 15.0.0",
- "polkadot-core-primitives 14.0.0",
- "polkadot-primitives 14.0.0",
- "polkadot-runtime-constants",
- "smallvec",
- "sp-core 34.0.0",
- "sp-runtime 38.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19917,21 +16167,6 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "testnet-parachains-constants"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "cumulus-primitives-core 0.17.0",
- "frame-support 39.0.0",
- "polkadot-core-primitives 16.0.0",
- "rococo-runtime-constants",
- "smallvec",
- "sp-runtime 40.1.0",
- "staging-xcm 15.0.1",
- "westend-runtime-constants",
-]
 
 [[package]]
 name = "thiserror"
@@ -20340,7 +16575,7 @@ version = "17.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
  "coarsetime",
- "polkadot-primitives 17.0.0",
+ "polkadot-primitives",
  "tracing",
  "tracing-gum-proc-macro",
 ]
@@ -20986,7 +17221,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c128c039340ffd50d4195c3f8ce31aac357f06804cfc494c8b9508d4b30dca4"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "hashbrown 0.14.5",
  "string-interner",
 ]
@@ -21031,7 +17266,7 @@ version = "0.220.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e246c2772ce3ebc83f89a2d4487ac5794cad6c309b2071818a88c7db7c36d87b"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "bitflags 2.8.0",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
@@ -21283,109 +17518,109 @@ name = "westend-runtime"
 version = "21.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "binary-merkle-tree 16.0.0",
+ "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 39.0.0",
- "frame-election-provider-support 39.0.0",
- "frame-executive 39.0.0",
- "frame-metadata-hash-extension 0.7.0",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "frame-system-benchmarking 39.0.0",
- "frame-system-rpc-runtime-api 35.0.0",
- "frame-try-runtime 0.45.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal",
  "log",
- "pallet-asset-rate 18.0.0",
- "pallet-authority-discovery 39.0.0",
- "pallet-authorship 39.0.0",
- "pallet-babe 39.0.0",
- "pallet-bags-list 38.0.0",
- "pallet-balances 40.0.0",
- "pallet-beefy 40.0.0",
- "pallet-beefy-mmr 40.0.0",
+ "pallet-asset-rate",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-bags-list",
+ "pallet-balances",
+ "pallet-beefy",
+ "pallet-beefy-mmr",
  "pallet-collective",
- "pallet-conviction-voting 39.0.0",
- "pallet-delegated-staking 6.0.0",
+ "pallet-conviction-voting",
+ "pallet-delegated-staking",
  "pallet-democracy",
- "pallet-election-provider-multi-phase 38.0.0",
- "pallet-election-provider-support-benchmarking 38.0.0",
+ "pallet-election-provider-multi-phase",
+ "pallet-election-provider-support-benchmarking",
  "pallet-elections-phragmen",
- "pallet-fast-unstake 38.0.0",
- "pallet-grandpa 39.0.0",
- "pallet-identity 39.0.0",
- "pallet-indices 39.0.0",
+ "pallet-fast-unstake",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-indices",
  "pallet-membership",
- "pallet-message-queue 42.0.0",
+ "pallet-message-queue",
  "pallet-migrations",
- "pallet-mmr 39.0.0",
- "pallet-multisig 39.0.0",
- "pallet-nomination-pools 37.0.0",
- "pallet-nomination-pools-benchmarking 37.0.0",
- "pallet-nomination-pools-runtime-api 35.0.0",
- "pallet-offences 38.0.0",
- "pallet-offences-benchmarking 39.0.0",
- "pallet-parameters 0.10.0",
- "pallet-preimage 39.0.0",
- "pallet-proxy 39.0.0",
+ "pallet-mmr",
+ "pallet-multisig",
+ "pallet-nomination-pools",
+ "pallet-nomination-pools-benchmarking",
+ "pallet-nomination-pools-runtime-api",
+ "pallet-offences",
+ "pallet-offences-benchmarking",
+ "pallet-parameters",
+ "pallet-preimage",
+ "pallet-proxy",
  "pallet-recovery",
- "pallet-referenda 39.0.0",
+ "pallet-referenda",
  "pallet-root-testing",
- "pallet-scheduler 40.0.0",
- "pallet-session 39.0.0",
- "pallet-session-benchmarking 39.0.0",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-session-benchmarking",
  "pallet-society",
- "pallet-staking 39.0.1",
- "pallet-staking-runtime-api 25.0.0",
- "pallet-state-trie-migration 43.0.0",
- "pallet-sudo 39.0.0",
- "pallet-timestamp 38.0.0",
- "pallet-transaction-payment 39.0.0",
- "pallet-transaction-payment-rpc-runtime-api 39.0.0",
- "pallet-treasury 38.0.0",
- "pallet-utility 39.0.0",
- "pallet-vesting 39.0.0",
- "pallet-whitelist 38.0.0",
- "pallet-xcm 18.0.0",
- "pallet-xcm-benchmarks 18.0.0",
+ "pallet-staking",
+ "pallet-staking-runtime-api",
+ "pallet-state-trie-migration",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-utility",
+ "pallet-vesting",
+ "pallet-whitelist",
+ "pallet-xcm",
+ "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-common 18.0.0",
- "polkadot-runtime-parachains 18.0.1",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "scale-info",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api 35.0.0",
- "sp-application-crypto 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-authority-discovery 35.0.0",
- "sp-block-builder 35.0.0",
- "sp-consensus-babe 0.41.0",
- "sp-consensus-beefy 23.0.0",
- "sp-consensus-grandpa 22.0.0",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-consensus-babe",
+ "sp-consensus-beefy",
+ "sp-consensus-grandpa",
  "sp-core 35.0.0",
- "sp-genesis-builder 0.16.0",
- "sp-inherents 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-io 39.0.0",
- "sp-keyring 40.0.0",
- "sp-mmr-primitives 35.0.0",
- "sp-npos-elections 35.0.0",
- "sp-offchain 35.0.0",
- "sp-runtime 40.1.0",
- "sp-session 37.0.0",
- "sp-staking 37.0.0",
+ "sp-keyring",
+ "sp-mmr-primitives",
+ "sp-npos-elections",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
  "sp-storage 22.0.0",
- "sp-transaction-pool 35.0.0",
- "sp-version 38.0.0",
+ "sp-transaction-pool",
+ "sp-version",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
- "staging-xcm-executor 18.0.0",
- "substrate-wasm-builder 25.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "substrate-wasm-builder",
  "westend-runtime-constants",
- "xcm-runtime-apis 0.5.0",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -21393,15 +17628,15 @@ name = "westend-runtime-constants"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-common 18.0.0",
+ "frame-support",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
  "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-builder 18.0.0",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -21817,56 +18052,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xcm-emulator"
-version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
-dependencies = [
- "array-bytes",
- "cumulus-pallet-parachain-system 0.18.0",
- "cumulus-pallet-xcmp-queue 0.18.0",
- "cumulus-primitives-core 0.17.0",
- "cumulus-primitives-parachain-inherent 0.17.0",
- "cumulus-test-relay-sproof-builder",
- "frame-support 39.0.0",
- "frame-system 39.1.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-balances 40.0.0",
- "pallet-message-queue 42.0.0",
- "parachains-common 19.0.0",
- "parity-scale-codec",
- "paste",
- "polkadot-parachain-primitives 15.0.0",
- "polkadot-primitives 17.0.0",
- "polkadot-runtime-parachains 18.0.1",
- "sp-arithmetic 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-core 35.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "sp-tracing 17.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
- "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
-]
-
-[[package]]
 name = "xcm-procedural"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4717a97970a9cda70d7db53cf50d2615c2f6f6b7c857445325b4a39ea7aa2cd"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "xcm-procedural"
-version = "10.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a95797c7b227a8466a65a16376bc275e1b8f2a5471325f00f6870314c45f9e"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -21887,32 +18076,16 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fffcd9128a46abd836c37dd001c2cbe122aeb8904cd7b9bac8358564fb7b56"
-dependencies = [
- "frame-support 36.0.1",
- "parity-scale-codec",
- "scale-info",
- "sp-api 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.0.3",
- "staging-xcm-executor 15.0.0",
-]
-
-[[package]]
-name = "xcm-runtime-apis"
 version = "0.5.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2412#9de8837d9d0acede6204893ae553c722e1097b03"
 dependencies = [
- "frame-support 39.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 35.0.0",
+ "sp-api",
  "sp-weights 31.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2412)",
  "staging-xcm 15.0.1",
- "staging-xcm-executor 18.0.0",
+ "staging-xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,3 +203,24 @@ ismp-parachain-runtime-api = { git = "https://github.com/r0gue-io/ismp", branch 
 pallet-ismp = { git = "https://github.com/r0gue-io/ismp", branch = "polkadot-stable2412", default-features = false }
 pallet-ismp-rpc = { git = "https://github.com/r0gue-io/ismp", branch = "polkadot-stable2412", default-features = false }
 pallet-ismp-runtime-api = { git = "https://github.com/r0gue-io/ismp", branch = "polkadot-stable2412", default-features = false }
+
+# Revive
+# array-bytes = { version = "6.2.2", default-features = false }
+# assert_matches = { version = "1.5.0" }
+# bitflags = { version = "1.3.2" }
+# environmental = { version = "1.1.4", default-features = false }
+# pallet-revive-fixtures = { path = "pallets/revive/fixtures", default-features = false }
+# pallet-revive-mock-network = { default-features = false, path = "pallets/revive/mock-network" }
+# pallet-revive-proc-macro = { path = "pallets/revive/proc-macro", default-features = false }
+# pallet-revive-uapi = { path = "pallets/revive/uapi", default-features = false }
+# parity-wasm = { version = "0.45.0" }
+# paste = { version = "1.0.14", default-features = false }
+# pretty_assertions = { version = "1.3.0" }
+# proc-macro2 = { version = "1.0.64" }
+# quote = { version = "1.0.33" }
+# rlp = { version = "0.5.2", default-features = false }
+# sp-tracing = { version = "16.0.0", default-features = false }
+# syn = { version = "2.0.53" }
+# tempfile = { version = "3.8.1" }
+# toml = { version = "0.8.8" }
+# wat = { version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ exclude = [
 	"extension/contract",
 	"pop-api",
 	"tests/contracts",
+	"integration-tests",
 ]
 members = [
-	"integration-tests",
 	"node",
 	"pallets/*",
 	"pop-api/integration-tests",

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -167,7 +167,7 @@ mod extension {
 		// Invalid encoded runtime call.
 		let input = vec![0u8, 99];
 		let mut env = MockEnvironment::new(DispatchExtFuncId::get(), input.clone());
-		let mut extension = Extension::<mock::Config>::default();
+		let mut extension: Extension<mock::Config> = Extension::<mock::Config>::default();
 		assert!(extension.call(&mut env).is_err());
 		// Charges weight.
 		assert_eq!(

--- a/pallets/api/Cargo.toml
+++ b/pallets/api/Cargo.toml
@@ -22,6 +22,7 @@ frame-benchmarking.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
 pallet-assets.workspace = true
+pallet-balances.workspace = true
 pallet-nfts.workspace = true
 sp-runtime.workspace = true
 sp-std.workspace = true
@@ -47,6 +48,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
 	"pallet-nfts/runtime-benchmarks",
 	"pop-chain-extension/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",

--- a/pallets/api/src/lib.rs
+++ b/pallets/api/src/lib.rs
@@ -5,10 +5,10 @@ use frame_support::pallet_prelude::Weight;
 
 pub mod extension;
 pub mod fungibles;
+pub mod messaging;
 #[cfg(test)]
 mod mock;
 pub mod nonfungibles;
-pub mod messaging;
 
 /// Trait for performing reads of runtime state.
 pub trait Read {

--- a/pallets/api/src/messaging/benchmarking.rs
+++ b/pallets/api/src/messaging/benchmarking.rs
@@ -1,0 +1,72 @@
+// //! Benchmarking setup for pallet_api::nonfungibles
+// #![cfg(feature = "runtime-benchmarks")]
+
+// use frame_benchmarking::{account, v2::*};
+// use frame_support::{BoundedVec, dispatch::RawOrigin, traits::Currency};
+// use sp_runtime::traits::Zero;
+
+
+// use super::*;
+// use crate::Read as _;
+// const SEED: u32 = 1;
+
+// // See if `generic_event` has been emitted.
+// fn assert_has_event<T: Config>
+// (generic_event: <T as crate::messaging::Config>::RuntimeEvent) 
+// where
+
+// {
+// 	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
+// }
+
+
+// #[benchmarks(
+// 	where
+// 	T: pallet_balances::Config
+// )]
+// mod messaging_benchmarks {
+// 	use super::*;
+
+// 	#[benchmark]
+// 	// x: The number of removals required.
+// 	fn remove(x: Linear<1, 255>) {
+// 		let deposit: BalanceOf<T> = sp_runtime::traits::One::one();
+// 		let owner: AccountIdOf<T> = account("Alice", 0, SEED);
+// 		let mut message_ids: BoundedVec<MessageId, T::MaxRemovals> = BoundedVec::new();
+// 		pallet_balances::Pallet::<T>::make_free_balance_be(&owner, u32::MAX.into());
+
+// 		for i in 0..x {
+// 			<T as crate::messaging::Config>::Deposit::hold(
+// 				&HoldReason::Messaging.into(),
+// 				&owner,
+// 				deposit,
+// 			)
+// 			.unwrap();
+			
+// 			let message_id = H256::repeat_byte(i as u8);
+// 			let commitment = H256::repeat_byte(i as u8);
+
+// 			let good_message = Message::IsmpResponse {
+// 				commitment: commitment.clone(),
+// 				deposit,
+// 				response: Default::default(),
+// 				status: MessageStatus::Ok,
+// 			};
+
+// 			Messages::<T>::insert(&owner, &message_id.0, &good_message);
+// 			IsmpRequests::<T>::insert(&commitment, (&owner, &message_id.0));
+// 			message_ids.try_push(message_id.0).unwrap()
+// 		}
+// 		#[extrinsic_call]
+// 		Pallet::<T>::remove(RawOrigin::Signed(owner.clone()), message_ids.clone());
+		
+// 		assert_has_event::<T>(
+// 			crate::messaging::Event::Removed {
+// 				origin: owner,
+// 				messages: message_ids.to_vec(),
+// 			}.into()
+// 		)
+// 	}
+
+// 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
+// }

--- a/pallets/api/src/messaging/benchmarking.rs
+++ b/pallets/api/src/messaging/benchmarking.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use frame_benchmarking::{account, v2::*};
-use frame_support::{BoundedVec, dispatch::RawOrigin, traits::Currency};
+use frame_support::{dispatch::RawOrigin, traits::Currency, BoundedVec};
 use sp_runtime::traits::Zero;
 
 use super::*;
@@ -10,11 +10,7 @@ use crate::Read as _;
 const SEED: u32 = 1;
 
 // See if `generic_event` has been emitted.
-fn assert_has_event<T: Config>
-(generic_event: <T as crate::messaging::Config>::RuntimeEvent)
-where
-
-{
+fn assert_has_event<T: Config>(generic_event: <T as crate::messaging::Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
 }
 
@@ -59,10 +55,8 @@ mod messaging_benchmarks {
 		Pallet::<T>::remove(RawOrigin::Signed(owner.clone()), message_ids.clone());
 
 		assert_has_event::<T>(
-			crate::messaging::Event::Removed {
-				origin: owner,
-				messages: message_ids.to_vec(),
-			}.into()
+			crate::messaging::Event::Removed { origin: owner, messages: message_ids.to_vec() }
+				.into(),
 		)
 	}
 

--- a/pallets/api/src/messaging/benchmarking.rs
+++ b/pallets/api/src/messaging/benchmarking.rs
@@ -1,72 +1,70 @@
-// //! Benchmarking setup for pallet_api::nonfungibles
-// #![cfg(feature = "runtime-benchmarks")]
+//! Benchmarking setup for pallet_api::nonfungibles
+#![cfg(feature = "runtime-benchmarks")]
 
-// use frame_benchmarking::{account, v2::*};
-// use frame_support::{BoundedVec, dispatch::RawOrigin, traits::Currency};
-// use sp_runtime::traits::Zero;
+use frame_benchmarking::{account, v2::*};
+use frame_support::{BoundedVec, dispatch::RawOrigin, traits::Currency};
+use sp_runtime::traits::Zero;
 
+use super::*;
+use crate::Read as _;
+const SEED: u32 = 1;
 
-// use super::*;
-// use crate::Read as _;
-// const SEED: u32 = 1;
+// See if `generic_event` has been emitted.
+fn assert_has_event<T: Config>
+(generic_event: <T as crate::messaging::Config>::RuntimeEvent)
+where
 
-// // See if `generic_event` has been emitted.
-// fn assert_has_event<T: Config>
-// (generic_event: <T as crate::messaging::Config>::RuntimeEvent) 
-// where
+{
+	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
+}
 
-// {
-// 	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
-// }
+#[benchmarks(
+	where
+	T: pallet_balances::Config
+)]
+mod messaging_benchmarks {
+	use super::*;
 
+	#[benchmark]
+	// x: The number of removals required.
+	fn remove(x: Linear<1, 255>) {
+		let deposit: BalanceOf<T> = sp_runtime::traits::One::one();
+		let owner: AccountIdOf<T> = account("Alice", 0, SEED);
+		let mut message_ids: BoundedVec<MessageId, T::MaxRemovals> = BoundedVec::new();
+		pallet_balances::Pallet::<T>::make_free_balance_be(&owner, u32::MAX.into());
 
-// #[benchmarks(
-// 	where
-// 	T: pallet_balances::Config
-// )]
-// mod messaging_benchmarks {
-// 	use super::*;
+		for i in 0..x {
+			<T as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&owner,
+				deposit,
+			)
+			.unwrap();
 
-// 	#[benchmark]
-// 	// x: The number of removals required.
-// 	fn remove(x: Linear<1, 255>) {
-// 		let deposit: BalanceOf<T> = sp_runtime::traits::One::one();
-// 		let owner: AccountIdOf<T> = account("Alice", 0, SEED);
-// 		let mut message_ids: BoundedVec<MessageId, T::MaxRemovals> = BoundedVec::new();
-// 		pallet_balances::Pallet::<T>::make_free_balance_be(&owner, u32::MAX.into());
+			let message_id = H256::repeat_byte(i as u8);
+			let commitment = H256::repeat_byte(i as u8);
 
-// 		for i in 0..x {
-// 			<T as crate::messaging::Config>::Deposit::hold(
-// 				&HoldReason::Messaging.into(),
-// 				&owner,
-// 				deposit,
-// 			)
-// 			.unwrap();
-			
-// 			let message_id = H256::repeat_byte(i as u8);
-// 			let commitment = H256::repeat_byte(i as u8);
+			let good_message = Message::IsmpResponse {
+				commitment: commitment.clone(),
+				deposit,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
 
-// 			let good_message = Message::IsmpResponse {
-// 				commitment: commitment.clone(),
-// 				deposit,
-// 				response: Default::default(),
-// 				status: MessageStatus::Ok,
-// 			};
+			Messages::<T>::insert(&owner, &message_id.0, &good_message);
+			IsmpRequests::<T>::insert(&commitment, (&owner, &message_id.0));
+			message_ids.try_push(message_id.0).unwrap()
+		}
+		#[extrinsic_call]
+		Pallet::<T>::remove(RawOrigin::Signed(owner.clone()), message_ids.clone());
 
-// 			Messages::<T>::insert(&owner, &message_id.0, &good_message);
-// 			IsmpRequests::<T>::insert(&commitment, (&owner, &message_id.0));
-// 			message_ids.try_push(message_id.0).unwrap()
-// 		}
-// 		#[extrinsic_call]
-// 		Pallet::<T>::remove(RawOrigin::Signed(owner.clone()), message_ids.clone());
-		
-// 		assert_has_event::<T>(
-// 			crate::messaging::Event::Removed {
-// 				origin: owner,
-// 				messages: message_ids.to_vec(),
-// 			}.into()
-// 		)
-// 	}
+		assert_has_event::<T>(
+			crate::messaging::Event::Removed {
+				origin: owner,
+				messages: message_ids.to_vec(),
+			}.into()
+		)
+	}
 
-// 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
-// }
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/pallets/api/src/messaging/deposits.rs
+++ b/pallets/api/src/messaging/deposits.rs
@@ -1,6 +1,6 @@
 
 use super::*;
-use sp_runtime::{traits::Zero, SaturatedConversion};
+use sp_runtime::SaturatedConversion;
 
 
 #[derive(Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]

--- a/pallets/api/src/messaging/deposits.rs
+++ b/pallets/api/src/messaging/deposits.rs
@@ -1,0 +1,43 @@
+
+use super::*;
+use sp_runtime::{traits::Zero, SaturatedConversion};
+
+
+#[derive(Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]
+pub enum ProtocolStorageDeposit {
+    XcmQueries,
+    IsmpRequests,
+}
+
+fn calculate_type_deposit<T: Config, U: MaxEncodedLen>() -> BalanceOf<T> {
+    T::ByteFee::get() * U::max_encoded_len().saturated_into() 
+}
+
+fn calculate_protocol_deposit<T: Config>(p: ProtocolStorageDeposit) -> BalanceOf<T> {
+    let base: usize = match p {
+        ProtocolStorageDeposit::XcmQueries => {
+            KeyLenOf::<XcmQueries<T>>::get() as usize +
+					AccountIdOf::<T>::max_encoded_len() +
+					MessageId::max_encoded_len() +
+					Option::<Callback<T::AccountId>>::max_encoded_len()
+        },
+        ProtocolStorageDeposit::IsmpRequests => {
+            KeyLenOf::<IsmpRequests<T>>::get() as usize +
+						AccountIdOf::<T>::max_encoded_len() +
+						MessageId::max_encoded_len()
+        },
+    };
+    T::ByteFee::get() * base.saturated_into()
+}
+
+fn calculate_message_deposit<T: Config>() -> BalanceOf<T> {
+    T::ByteFee::get() * (KeyLenOf::<Messages<T>>::get() as usize + Message::<T>::max_encoded_len()).saturated_into()
+}
+
+
+pub fn calculate_deposit<T: Config, U: MaxEncodedLen>(p: ProtocolStorageDeposit) -> BalanceOf<T> {
+    calculate_type_deposit::<T, U>()
+    .saturating_add(calculate_protocol_deposit::<T>(p))
+    .saturating_add(calculate_message_deposit::<T>())
+}
+

--- a/pallets/api/src/messaging/deposits.rs
+++ b/pallets/api/src/messaging/deposits.rs
@@ -1,43 +1,40 @@
-
-use super::*;
 use sp_runtime::SaturatedConversion;
 
+use super::*;
 
 #[derive(Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]
 pub enum ProtocolStorageDeposit {
-    XcmQueries,
-    IsmpRequests,
+	XcmQueries,
+	IsmpRequests,
 }
 
 fn calculate_type_deposit<T: Config, U: MaxEncodedLen>() -> BalanceOf<T> {
-    T::ByteFee::get() * U::max_encoded_len().saturated_into() 
+	T::ByteFee::get() * U::max_encoded_len().saturated_into()
 }
 
 fn calculate_protocol_deposit<T: Config>(p: ProtocolStorageDeposit) -> BalanceOf<T> {
-    let base: usize = match p {
-        ProtocolStorageDeposit::XcmQueries => {
-            KeyLenOf::<XcmQueries<T>>::get() as usize +
-					AccountIdOf::<T>::max_encoded_len() +
-					MessageId::max_encoded_len() +
-					Option::<Callback<T::AccountId>>::max_encoded_len()
-        },
-        ProtocolStorageDeposit::IsmpRequests => {
-            KeyLenOf::<IsmpRequests<T>>::get() as usize +
-						AccountIdOf::<T>::max_encoded_len() +
-						MessageId::max_encoded_len()
-        },
-    };
-    T::ByteFee::get() * base.saturated_into()
+	let base: usize = match p {
+		ProtocolStorageDeposit::XcmQueries =>
+			KeyLenOf::<XcmQueries<T>>::get() as usize +
+				AccountIdOf::<T>::max_encoded_len() +
+				MessageId::max_encoded_len() +
+				Option::<Callback<T::AccountId>>::max_encoded_len(),
+		ProtocolStorageDeposit::IsmpRequests =>
+			KeyLenOf::<IsmpRequests<T>>::get() as usize +
+				AccountIdOf::<T>::max_encoded_len() +
+				MessageId::max_encoded_len(),
+	};
+	T::ByteFee::get() * base.saturated_into()
 }
 
 fn calculate_message_deposit<T: Config>() -> BalanceOf<T> {
-    T::ByteFee::get() * (KeyLenOf::<Messages<T>>::get() as usize + Message::<T>::max_encoded_len()).saturated_into()
+	T::ByteFee::get() *
+		(KeyLenOf::<Messages<T>>::get() as usize + Message::<T>::max_encoded_len())
+			.saturated_into()
 }
-
 
 pub fn calculate_deposit<T: Config, U: MaxEncodedLen>(p: ProtocolStorageDeposit) -> BalanceOf<T> {
-    calculate_type_deposit::<T, U>()
-    .saturating_add(calculate_protocol_deposit::<T>(p))
-    .saturating_add(calculate_message_deposit::<T>())
+	calculate_type_deposit::<T, U>()
+		.saturating_add(calculate_protocol_deposit::<T>(p))
+		.saturating_add(calculate_message_deposit::<T>())
 }
-

--- a/pallets/api/src/messaging/deposits.rs
+++ b/pallets/api/src/messaging/deposits.rs
@@ -1,7 +1,7 @@
 use sp_runtime::SaturatedConversion;
+use sp_std::ops::Mul;
 
 use super::*;
-use sp_std::ops::Mul;
 
 #[derive(Clone, Debug, Encode, Eq, Decode, MaxEncodedLen, PartialEq, TypeInfo)]
 pub enum ProtocolStorageDeposit {
@@ -10,7 +10,9 @@ pub enum ProtocolStorageDeposit {
 }
 
 /// Calculate the deposit required for the space used for a specific protocol.
-pub fn calculate_protocol_deposit<T: Config, ByteFee: Get<BalanceOf<T>>>(p: ProtocolStorageDeposit) -> BalanceOf<T> {
+pub fn calculate_protocol_deposit<T: Config, ByteFee: Get<BalanceOf<T>>>(
+	p: ProtocolStorageDeposit,
+) -> BalanceOf<T> {
 	let base: usize = match p {
 		ProtocolStorageDeposit::XcmQueries =>
 			KeyLenOf::<XcmQueries<T>>::get() as usize +
@@ -33,7 +35,7 @@ pub fn calculate_message_deposit<T: Config, ByteFee: Get<BalanceOf<T>>>() -> Bal
 }
 
 /// Blanket implementation of generating the deposit for a type that implements MaxEncodedLen.
-pub fn calculate_deposit_of<T: Config, ByteFee: Get<BalanceOf<T>>, U: MaxEncodedLen>() -> BalanceOf<T> {
+pub fn calculate_deposit_of<T: Config, ByteFee: Get<BalanceOf<T>>, U: MaxEncodedLen>(
+) -> BalanceOf<T> {
 	ByteFee::get() * U::max_encoded_len().saturated_into()
 }
-

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -262,9 +262,9 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = 
-				calculate_protocol_deposit::<T, T::OnChainByteFee>(ProtocolStorageDeposit::IsmpRequests) +
-				calculate_message_deposit::<T, T::OnChainByteFee>() + 
+			let deposit = calculate_protocol_deposit::<T, T::OnChainByteFee>(
+				ProtocolStorageDeposit::IsmpRequests,
+			) + calculate_message_deposit::<T, T::OnChainByteFee>() +
 				calculate_deposit_of::<T, T::OffChainByteFee, ismp::Get<T>>();
 
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
@@ -326,9 +326,9 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = 
-				calculate_protocol_deposit::<T, T::OnChainByteFee>(ProtocolStorageDeposit::IsmpRequests) +
-				calculate_message_deposit::<T, T::OnChainByteFee>() +
+			let deposit = calculate_protocol_deposit::<T, T::OnChainByteFee>(
+				ProtocolStorageDeposit::IsmpRequests,
+			) + calculate_message_deposit::<T, T::OnChainByteFee>() +
 				calculate_deposit_of::<T, T::OffChainByteFee, ismp::Post<T>>();
 
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
@@ -392,9 +392,9 @@ pub mod pallet {
 
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = 
-				calculate_protocol_deposit::<T, T::OnChainByteFee>(ProtocolStorageDeposit::IsmpRequests) +
-				calculate_message_deposit::<T, T::OnChainByteFee>();
+			let deposit = calculate_protocol_deposit::<T, T::OnChainByteFee>(
+				ProtocolStorageDeposit::IsmpRequests,
+			) + calculate_message_deposit::<T, T::OnChainByteFee>();
 
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
 

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -32,7 +32,7 @@ pub mod transports;
 
 /// Message storage deposit calculations.
 mod deposits;
-use deposits::{ProtocolStorageDeposit, calculate_deposit};
+use deposits::{calculate_deposit, ProtocolStorageDeposit};
 
 #[cfg(test)]
 mod tests;
@@ -46,9 +46,7 @@ pub type MessageId = [u8; 32];
 pub mod pallet {
 
 	use frame_support::{
-		dispatch::DispatchResult,
-		pallet_prelude::*,
-		traits::tokens::fungible::hold::Mutate,
+		dispatch::DispatchResult, pallet_prelude::*, traits::tokens::fungible::hold::Mutate,
 	};
 	use sp_core::H256;
 	use sp_runtime::traits::TryConvert;
@@ -77,7 +75,6 @@ pub mod pallet {
 		type Deposit: Mutate<Self::AccountId, Reason = Self::RuntimeHoldReason>
 			+ Inspect<Self::AccountId>;
 
-		
 		/// The ISMP message dispatcher.
 		type IsmpDispatcher: IsmpDispatcher<Account = Self::AccountId, Balance = BalanceOf<Self>>;
 
@@ -265,7 +262,8 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = calculate_deposit::<T, ismp::Get<T>>(ProtocolStorageDeposit::IsmpRequests);
+			let deposit =
+				calculate_deposit::<T, ismp::Get<T>>(ProtocolStorageDeposit::IsmpRequests);
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
 
 			// Process message by dispatching request via ISMP.
@@ -325,7 +323,8 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = calculate_deposit::<T, ismp::Post<T>>(ProtocolStorageDeposit::IsmpRequests);
+			let deposit =
+				calculate_deposit::<T, ismp::Post<T>>(ProtocolStorageDeposit::IsmpRequests);
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
 
 			// Process message by dispatching request via ISMP.

--- a/pallets/api/src/messaging/mod.rs
+++ b/pallets/api/src/messaging/mod.rs
@@ -1,5 +1,3 @@
-//! TODO: pallet docs.
-
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchResult, DispatchResultWithPostInfo, PostDispatchInfo},
@@ -15,8 +13,8 @@ use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use scale_info::TypeInfo;
 use sp_core::H256;
-use sp_runtime::{traits::Saturating, BoundedVec, DispatchError, SaturatedConversion};
-use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+use sp_runtime::{traits::Saturating, BoundedVec, DispatchError};
+use sp_std::vec::Vec;
 use transports::{
 	ismp::{self as ismp, FeeMetadata, IsmpDispatcher},
 	xcm::{self as xcm, Location, QueryId},
@@ -50,8 +48,7 @@ pub mod pallet {
 	use frame_support::{
 		dispatch::DispatchResult,
 		pallet_prelude::*,
-		storage::KeyLenOf,
-		traits::tokens::{fungible::hold::Mutate, Precision::Exact},
+		traits::tokens::fungible::hold::Mutate,
 	};
 	use sp_core::H256;
 	use sp_runtime::traits::TryConvert;
@@ -268,7 +265,7 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = deposits::calculate_deposit::<T, ismp::Get<T>>(ProtocolStorageDeposit::IsmpRequests);
+			let deposit = calculate_deposit::<T, ismp::Get<T>>(ProtocolStorageDeposit::IsmpRequests);
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
 
 			// Process message by dispatching request via ISMP.
@@ -298,7 +295,7 @@ pub mod pallet {
 					});
 					Ok(())
 				},
-				Err(e) => {
+				Err(_) => {
 					// Allow a caller to poll for the status still and retreive the message deposit.
 					Messages::<T>::insert(
 						&origin,
@@ -328,7 +325,7 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = deposits::calculate_deposit::<T, ismp::Post<T>>(ProtocolStorageDeposit::IsmpRequests);
+			let deposit = calculate_deposit::<T, ismp::Post<T>>(ProtocolStorageDeposit::IsmpRequests);
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
 
 			// Process message by dispatching request via ISMP.
@@ -358,7 +355,7 @@ pub mod pallet {
 					});
 					Ok(())
 				},
-				Err(e) => {
+				Err(_) => {
 					// Allow a caller to poll for the status still and retreive the message deposit.
 					Messages::<T>::insert(
 						&origin,
@@ -390,7 +387,7 @@ pub mod pallet {
 
 			ensure!(!Messages::<T>::contains_key(&origin, &id), Error::<T>::MessageExists);
 
-			let deposit = deposits::calculate_deposit::<T, ()>(ProtocolStorageDeposit::XcmQueries);
+			let deposit = calculate_deposit::<T, ()>(ProtocolStorageDeposit::XcmQueries);
 			T::Deposit::hold(&HoldReason::Messaging.into(), &origin, deposit)?;
 
 			// Process message by creating new query via XCM.
@@ -480,7 +477,7 @@ pub mod pallet {
 		#[pallet::weight(Weight::zero())]
 		pub fn remove(
 			origin: OriginFor<T>,
-			mut messages: BoundedVec<MessageId, T::MaxRemovals>,
+			messages: BoundedVec<MessageId, T::MaxRemovals>,
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -2,7 +2,7 @@ use codec::Encode;
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::WithPostDispatchInfo,
-	sp_runtime::{traits::Zero, BoundedVec, DispatchError::BadOrigin},
+	sp_runtime::{traits::Zero, DispatchError::BadOrigin},
 	testing_prelude::bounded_vec,
 	weights::Weight,
 };
@@ -11,176 +11,574 @@ use sp_core::H256;
 
 use crate::{messaging::*, mock::*, Read};
 
-mod remove {
+fn events() -> Vec<Event<Test>> {
+	let result = System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| if let crate::mock::RuntimeEvent::Messaging(inner) = e { Some(inner) } else { None })
+		.collect::<Vec<_>>();
+
+	System::reset_events();
+
+	result
+}
+
+
+// All the tests for the Message enum impls.
+mod message {
 	use super::*;
+
+	// Basic remove tests to ensure storage is cleaned.
 	#[test]
-	fn ismp_message_is_noop_when_status_is_ok() {
+	fn remove_ismp_message() {
 		new_test_ext().execute_with(|| {
+			let commitment = H256::default();
+			let message_id = [0u8; 32];
+			let m = Message::Ismp {
+				commitment,
+				callback: None,
+				deposit: 100,
+				status: MessageStatus::Ok,
+			};
+			Messages::<Test>::insert(&ALICE, &message_id, &m);
+			IsmpRequests::<Test>::insert(&commitment, (&ALICE, &message_id));
+			m.remove(&ALICE, &message_id);
+			assert!(
+				Messages::<Test>::get(&ALICE, &message_id).is_none(),
+				"Message should have been removed but hasnt."
+			);
+			assert!(
+				IsmpRequests::<Test>::get(&commitment).is_none(),
+				"Request should have been removed but hasnt."
+			);
+		})
+	}
+
+	#[test]
+	fn remove_ismp_response() {
+		new_test_ext().execute_with(|| {
+			let commitment = H256::default();
+			let message_id = [0u8; 32];
+			let m = Message::IsmpResponse {
+				commitment,
+				response: bounded_vec!(),
+				deposit: 100,
+				status: MessageStatus::Ok,
+			};
+			Messages::<Test>::insert(&ALICE, &message_id, &m);
+			IsmpRequests::<Test>::insert(&commitment, (&ALICE, &message_id));
+			m.remove(&ALICE, &message_id);
+			assert!(
+				Messages::<Test>::get(&ALICE, &message_id).is_none(),
+				"Message should have been removed but hasnt."
+			);
+			assert!(
+				IsmpRequests::<Test>::get(&commitment).is_none(),
+				"Request should have been removed but hasnt."
+			);
+		})
+	}
+
+	#[test]
+	fn remove_xcm_query() {
+		new_test_ext().execute_with(|| {
+			let query_id = 0;
+			let message_id = [0u8; 32];
+			let m = Message::XcmQuery {
+				query_id,
+				callback: None,
+				deposit: 0,
+				status: MessageStatus::Ok,
+			};
+			Messages::<Test>::insert(&ALICE, &message_id, &m);
+			XcmQueries::<Test>::insert(query_id, (&ALICE, &message_id));
+			m.remove(&ALICE, &message_id);
+			assert!(
+				Messages::<Test>::get(&ALICE, &message_id).is_none(),
+				"Message should have been removed but hasnt"
+			);
+			assert!(
+				XcmQueries::<Test>::get(query_id).is_none(),
+				"Message should have been removed but hasnt."
+			);
+		})
+	}
+
+	#[test]
+	fn remove_xcm_response() {
+		new_test_ext().execute_with(|| {
+			let query_id = 0;
+			let message_id = [0u8; 32];
+			let m = Message::XcmResponse {
+				query_id,
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+			Messages::<Test>::insert(&ALICE, &message_id, &m);
+			XcmQueries::<Test>::insert(query_id, (&ALICE, &message_id));
+			m.remove(&ALICE, &message_id);
+			assert!(
+				Messages::<Test>::get(&ALICE, &message_id).is_none(),
+				"Message should have been removed but hasnt"
+			);
+			assert!(
+				XcmQueries::<Test>::get(query_id).is_none(),
+				"Message should have been removed but hasnt."
+			);
+		})
+	}
+
+	// Basic try_remove tests to ensure validation of message status is correct.
+	#[test]
+	fn try_remove_ismp_message_is_noop_when_status_is_ok() {
+		new_test_ext().execute_with(|| {
+			let message_id: MessageId = [0u8; 32];
 			let m = Message::Ismp {
 				commitment: H256::default(),
 				callback: None,
 				deposit: 100,
 				status: MessageStatus::Ok,
 			};
-			let message_id: MessageId = [0u8; 32];
-			Messages::<Test>::insert(&ALICE, message_id, &m);
-			assert_noop!(
-				Messaging::remove(signed(ALICE), bounded_vec!(message_id)),
-				Error::<Test>::RequestPending
-			);
+			Messages::<Test>::insert(&ALICE, &message_id, &m);
+			assert_noop!(m.try_remove(&ALICE, &message_id), Error::<Test>::RequestPending);
 			assert!(
-				Messages::<Test>::get(ALICE, message_id).is_some(),
+				Messages::<Test>::get(ALICE, &message_id).is_some(),
 				"Message has been deleted when it should exist."
 			);
 		});
 	}
 
 	#[test]
-	fn ismp_message_is_removed_and_deposit_returned_when_status_is_timeout() {
+	fn try_remove_ismp_message_is_ok_when_status_is_timeout() {
 		new_test_ext().execute_with(|| {
-			let deposit: Balance = 100;
 			let message_id: MessageId = [0u8; 32];
 			let m = Message::Ismp {
 				commitment: H256::default(),
 				callback: None,
-				deposit,
+				deposit: 0,
 				status: MessageStatus::Timeout,
 			};
-			let alice_balance_pre_hold = Balances::free_balance(&ALICE);
-
-			<Test as crate::messaging::Config>::Deposit::hold(
-				&HoldReason::Messaging.into(),
-				&ALICE,
-				deposit,
-			)
-			.unwrap();
-
-			let alice_balance_post_hold = Balances::free_balance(&ALICE);
-
 			Messages::<Test>::insert(&ALICE, message_id, &m);
-			assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
-
-			let alice_balance_post_remove = Balances::free_balance(&ALICE);
-
-			assert_eq!(
-				alice_balance_post_hold + deposit,
-				alice_balance_pre_hold,
-				"deposit amount is incorrect"
-			);
-			assert_eq!(
-				alice_balance_post_remove, alice_balance_pre_hold,
-				"alice balance has been mutated when it shouldnt have."
-			);
+			assert_ok!(m.try_remove(&ALICE, &message_id));
 			assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
 		});
 	}
 
 	#[test]
-	fn ismp_message_is_removed_and_deposit_returned_when_status_is_err() {
+	fn try_remove_ismp_message_is_ok_when_status_is_err() {
 		new_test_ext().execute_with(|| {
-			let deposit: Balance = 100;
 			let message_id: MessageId = [0u8; 32];
 			let m = Message::Ismp {
 				commitment: H256::default(),
 				callback: None,
-				deposit,
+				deposit: 0,
 				status: MessageStatus::Err(Error::<Test>::IsmpDispatchFailed.into()),
 			};
-			let alice_balance_pre_hold = Balances::free_balance(&ALICE);
-
-			<Test as crate::messaging::Config>::Deposit::hold(
-				&HoldReason::Messaging.into(),
-				&ALICE,
-				deposit,
-			)
-			.unwrap();
-
-			let alice_balance_post_hold = Balances::free_balance(&ALICE);
-
 			Messages::<Test>::insert(&ALICE, message_id, &m);
-			assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
-
-			let alice_balance_post_remove = Balances::free_balance(&ALICE);
-
-			assert_eq!(
-				alice_balance_post_hold + deposit,
-				alice_balance_pre_hold,
-				"deposit amount is incorrect"
-			);
-			assert_eq!(
-				alice_balance_post_remove, alice_balance_pre_hold,
-				"alice balance has been mutated when it shouldnt have."
-			);
+			assert_ok!(m.try_remove(&ALICE, &message_id));
 			assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
 		});
 	}
 
 	#[test]
-	fn ismp_response_message_can_always_be_removed() {
-		new_test_ext().execute_with(|| {});
-	}
-	#[test]
-	fn xcm_queries_cannot_be_removed() {
+	fn try_remove_ismp_response_is_ok_any_status() {
 		new_test_ext().execute_with(|| {
-			let m_1_id = [0; 32];
-			let m_1 = Message::XcmQuery {
+			let m_id = [0; 32];
+			let m2_id = [1; 32];
+			let m3_id = [2; 32];
+
+			let m = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+			let m2 = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+
+			let m3 = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+
+			Messages::<Test>::insert(&ALICE, m_id, &m);
+			Messages::<Test>::insert(&ALICE, m2_id, &m2);
+			Messages::<Test>::insert(&ALICE, m3_id, &m3);
+
+			assert_ok!(m.try_remove(&ALICE, &m_id));
+			assert_ok!(m.try_remove(&ALICE, &m2_id));
+			assert_ok!(m.try_remove(&ALICE, &m3_id));
+
+			assert!(Messages::<Test>::get(&ALICE, m_id).is_none());
+			assert!(Messages::<Test>::get(&ALICE, m2_id).is_none());
+			assert!(Messages::<Test>::get(&ALICE, m3_id).is_none());
+		});
+	}
+
+	#[test]
+	fn try_remove_xcm_query_is_noop_when_status_is_ok() {
+		new_test_ext().execute_with(|| {
+			let message_id: MessageId = [0u8; 32];
+			let m = Message::XcmQuery {
 				query_id: 0,
 				callback: None,
 				deposit: 0,
 				status: MessageStatus::Ok,
 			};
-			let m_2_id = [1; 32];
-			let m_2 = Message::XcmQuery {
-				query_id: 1,
+			Messages::<Test>::insert(&ALICE, message_id, &m);
+			assert_noop!(m.try_remove(&ALICE, &message_id), Error::<Test>::RequestPending);
+			assert!(Messages::<Test>::get(&ALICE, message_id).is_some());
+		});
+	}
+
+	#[test]
+	fn try_remove_xcm_query_is_ok_when_status_is_timeout() {
+		new_test_ext().execute_with(|| {
+			let message_id: MessageId = [0u8; 32];
+			let m = Message::XcmQuery {
+				query_id: 0,
 				callback: None,
 				deposit: 0,
 				status: MessageStatus::Timeout,
 			};
-			let m_3_id = [2; 32];
-			let m_3 = Message::XcmQuery {
-				query_id: 2,
+			Messages::<Test>::insert(&ALICE, message_id, &m);
+			assert_ok!(m.try_remove(&ALICE, &message_id));
+			assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
+		});
+	}
+
+	#[test]
+	fn try_remove_xcm_query_is_ok_when_status_is_err() {
+		new_test_ext().execute_with(|| {
+			let message_id: MessageId = [0u8; 32];
+			let m = Message::XcmQuery {
+				query_id: 0,
 				callback: None,
 				deposit: 0,
-				status: MessageStatus::Err(Error::<Test>::InvalidQuery.into()),
+				status: MessageStatus::Err(Error::<Test>::IsmpDispatchFailed.into()),
 			};
-			Messages::<Test>::insert(&ALICE, m_1_id, &m_1);
-			Messages::<Test>::insert(&ALICE, m_2_id, &m_2);
-			Messages::<Test>::insert(&ALICE, m_3_id, &m_3);
+			Messages::<Test>::insert(&ALICE, message_id, &m);
+			assert_ok!(m.try_remove(&ALICE, &message_id));
+			assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
+		});
+	}
+
+	#[test]
+	fn try_remove_xcm_response_is_ok_any_status() {
+		new_test_ext().execute_with(|| {
+			let m_id = [0; 32];
+			let m2_id = [1; 32];
+			let m3_id = [2; 32];
+
+			let m = Message::XcmResponse {
+				query_id: 0,
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+
+			let m2 = Message::XcmResponse {
+				query_id: 0,
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Timeout,
+			};
+
+			let m3 = Message::XcmResponse {
+				query_id: 0,
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Err(Error::<Test>::InvalidMessage.into()),
+			};
+
+			Messages::<Test>::insert(&ALICE, m_id, &m);
+			Messages::<Test>::insert(&ALICE, m2_id, &m2);
+			Messages::<Test>::insert(&ALICE, m3_id, &m3);
+
+			assert_ok!(m.try_remove(&ALICE, &m_id));
+			assert_ok!(m.try_remove(&ALICE, &m2_id));
+			assert_ok!(m.try_remove(&ALICE, &m3_id));
+
+			assert!(Messages::<Test>::get(&ALICE, m_id).is_none());
+			assert!(Messages::<Test>::get(&ALICE, m2_id).is_none());
+			assert!(Messages::<Test>::get(&ALICE, m3_id).is_none());
+		});
+	}
+
+	// Basic release deposit to ensure quantites are correct.
+}
+
+// Tests for the remove extrinsic.
+mod remove {
+	use super::*;
+
+	#[test]
+	fn success_event() {
+		new_test_ext().execute_with(|| {
+
+		let deposit: Balance = 100;
+		let m = Message::IsmpResponse {
+			commitment: Default::default(),
+			deposit,
+			response: Default::default(),
+			status: MessageStatus::Ok,
+		};
+		let m_id = [0u8; 32];
+		let m2_id = [1u8; 32];
+
+		Messages::<Test>::insert(&ALICE, m_id, &m);
+		Messages::<Test>::insert(&ALICE, m2_id, &m);
+
+		<Test as crate::messaging::Config>::Deposit::hold(
+			&HoldReason::Messaging.into(),
+			&ALICE,
+			deposit,
+		)
+		.unwrap();
+		<Test as crate::messaging::Config>::Deposit::hold(
+			&HoldReason::Messaging.into(),
+			&ALICE,
+			deposit,
+		)
+		.unwrap();
+
+		assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(m_id, m2_id)));
+
+		assert!(events().contains(
+			&Event::<Test>::Removed {
+				origin: ALICE,
+				messages: vec![m_id, m2_id]
+			}
+		));
+
+		})
+	}
+
+	#[test]
+	fn message_not_found() {
+		new_test_ext().execute_with(|| {
 			assert_noop!(
-				Messaging::remove(signed(ALICE), bounded_vec!(m_1_id)),
-				Error::<Test>::RequestPending
+				Messaging::remove(signed(ALICE), bounded_vec!(Default::default())),
+				Error::<Test>::MessageNotFound
 			);
-			assert_noop!(
-				Messaging::remove(signed(ALICE), bounded_vec!(m_2_id)),
-				Error::<Test>::RequestPending
-			);
-			assert_noop!(
-				Messaging::remove(signed(ALICE), bounded_vec!(m_3_id)),
-				Error::<Test>::RequestPending
+		})
+	}
+
+	#[test]
+	fn multiple_messages_remove_works() {
+		new_test_ext().execute_with(|| {
+			let deposit: Balance = 100;
+			// An ismp response can always be removed.
+			let m = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+			let m_id = [0; 32];
+			let m2_id = [1; 32];
+			let m3_id = [2; 32];
+
+			Messages::<Test>::insert(&ALICE, m_id, &m);
+			Messages::<Test>::insert(&ALICE, m2_id, &m);
+			Messages::<Test>::insert(&ALICE, m3_id, &m);
+
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+
+			assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(m_id, m2_id, m3_id)));
+
+			assert!(
+				Messages::<Test>::get(&ALICE, m_id).is_none(),
+				"Message should have been removed."
 			);
 			assert!(
-				Messages::<Test>::get(ALICE, &m_1_id).is_some(),
-				"Message has been deleted when it should still exist."
+				Messages::<Test>::get(&ALICE, m2_id).is_none(),
+				"Message should have been removed."
 			);
 			assert!(
-				Messages::<Test>::get(ALICE, &m_2_id).is_some(),
-				"Message has been deleted when it should still exist."
-			);
-			assert!(
-				Messages::<Test>::get(ALICE, &m_3_id).is_some(),
-				"Message has been deleted when it should still exist."
+				Messages::<Test>::get(&ALICE, m3_id).is_none(),
+				"Message should have been removed."
 			);
 		});
 	}
 
 	#[test]
-	fn xcm_response_messages_can_always_be_removed() {
-		new_test_ext().execute_with(|| {});
+	fn deposit_is_returned_if_try_remove_is_ok() {
+		new_test_ext().execute_with(|| {
+			let alice_initial_balance = Balances::free_balance(&ALICE);
+			let deposit: Balance = 100;
+			// An ismp response can always be removed.
+			let m = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+			let m_id = [0; 32];
+
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE, 
+				deposit,
+			)
+			.unwrap();
+			Messages::<Test>::insert(&ALICE, m_id, &m);
+
+			let alice_balance_post_hold = Balances::free_balance(&ALICE);
+
+			assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(m_id)));
+
+			let alice_balance_post_remove = Balances::free_balance(&ALICE);
+
+			assert_eq!(alice_initial_balance, alice_balance_post_remove);
+			assert_eq!(alice_balance_post_remove, alice_balance_post_hold + deposit);
+		});
 	}
 
 	#[test]
-	fn multiple_messages_remove_works() {
-		new_test_ext().execute_with(|| {});
+	fn deposit_is_not_returned_if_try_remove_is_noop() {
+		new_test_ext().execute_with(|| {
+			let alice_initial_balance = Balances::free_balance(&ALICE);
+			let deposit: Balance = 100;
+
+			// Ismp message with status of Ok is considered pending.
+			let m = Message::Ismp {
+				commitment: H256::default(),
+				callback: None,
+				deposit,
+				status: MessageStatus::Ok,
+			};
+			let m_id = [0; 32];
+
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+			Messages::<Test>::insert(&ALICE, m_id, &m);
+
+			let alice_balance_post_hold = Balances::free_balance(&ALICE);
+
+			assert_noop!(
+				Messaging::remove(signed(ALICE), bounded_vec!(m_id)),
+				Error::<Test>::RequestPending
+			);
+
+			let alice_balance_post_remove = Balances::free_balance(&ALICE);
+
+			assert_eq!(alice_initial_balance, alice_balance_post_remove + deposit);
+			assert_eq!(alice_balance_post_remove, alice_balance_post_hold);
+		});
+	}
+
+	#[test]
+	fn multiple_messages_rolls_back_if_one_fails() {
+		new_test_ext().execute_with(|| {
+			let deposit: Balance = 100;
+			let alice_initial_balance = Balances::free_balance(&ALICE);
+			let good_message = Message::IsmpResponse {
+				commitment: Default::default(),
+				deposit: 0,
+				response: Default::default(),
+				status: MessageStatus::Ok,
+			};
+
+			let erroneous_message = Message::Ismp {
+				commitment: H256::default(),
+				callback: None,
+				deposit: 100,
+				status: MessageStatus::Ok,
+			};
+
+			let good_id_1 = [0; 32];
+			let good_id_2 = [1; 32];
+			let good_id_3 = [2; 32];
+			let good_id_4 = [3; 32];
+			let erroneous_id_1 = [4; 32];
+
+			Messages::<Test>::insert(&ALICE, good_id_1, &good_message);
+			Messages::<Test>::insert(&ALICE, good_id_2, &good_message);
+			Messages::<Test>::insert(&ALICE, good_id_3, &good_message);
+			Messages::<Test>::insert(&ALICE, good_id_4, &good_message);
+			Messages::<Test>::insert(&ALICE, erroneous_id_1, &erroneous_message);
+
+			// gonna do 5 messages.
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
+
+			let alice_balance_post_hold = Balances::free_balance(&ALICE);
+
+			assert_noop!(
+				Messaging::remove(
+					signed(ALICE),
+					bounded_vec!(good_id_1, good_id_2, good_id_3, good_id_4, erroneous_id_1)
+				),
+				Error::<Test>::RequestPending
+			);
+
+			assert!(Messages::<Test>::get(&ALICE, good_id_1).is_some());
+			assert!(Messages::<Test>::get(&ALICE, good_id_2).is_some());
+			assert!(Messages::<Test>::get(&ALICE, good_id_3).is_some());
+			assert!(Messages::<Test>::get(&ALICE, good_id_4).is_some());
+			assert!(Messages::<Test>::get(&ALICE, erroneous_id_1).is_some());
+
+			let alice_balance_post_remove = Balances::free_balance(&ALICE);
+			assert_eq!(alice_initial_balance, alice_balance_post_hold + deposit * 5);
+			assert_eq!(alice_balance_post_remove, alice_balance_post_hold);
+		});
 	}
 
 	#[test]

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -3,123 +3,188 @@ use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::WithPostDispatchInfo,
 	sp_runtime::{traits::Zero, BoundedVec, DispatchError::BadOrigin},
+	testing_prelude::bounded_vec,
 	weights::Weight,
 };
 use pallet_nfts::{CollectionSetting, MintWitness, WeightInfo as NftsWeightInfoTrait};
-
-use crate::{
-	mock::*,
-	Read,
-    messaging::*,
-};
 use sp_core::H256;
-use frame_support::testing_prelude::bounded_vec;
 
-    mod remove {
-        use super::*;
-        #[test]
-        fn ismp_message_is_noop_when_status_is_ok() {
-            new_test_ext().execute_with(|| {
-                let m = Message::Ismp { commitment: H256::default(), callback: None, deposit: 100, status: MessageStatus::Ok };
-                let message_id: MessageId =  [0u8; 32];
-                Messages::<Test>::insert(&ALICE, message_id, &m);
-                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)), Error::<Test>::RequestPending);
-                assert!(Messages::<Test>::get(ALICE, message_id).is_some(), "Message has been deleted when it should exist.");
-            });
-        }
+use crate::{messaging::*, mock::*, Read};
 
-        #[test]
-        fn ismp_message_is_removed_and_deposit_returned_when_status_is_timeout() {
-            new_test_ext().execute_with(|| {
-                let deposit: Balance = 100;
-                let message_id: MessageId =  [0u8; 32];
-                let m = Message::Ismp { commitment: H256::default(), callback: None, deposit, status: MessageStatus::Timeout };
-                let alice_balance_pre_hold = Balances::free_balance(&ALICE);
+mod remove {
+	use super::*;
+	#[test]
+	fn ismp_message_is_noop_when_status_is_ok() {
+		new_test_ext().execute_with(|| {
+			let m = Message::Ismp {
+				commitment: H256::default(),
+				callback: None,
+				deposit: 100,
+				status: MessageStatus::Ok,
+			};
+			let message_id: MessageId = [0u8; 32];
+			Messages::<Test>::insert(&ALICE, message_id, &m);
+			assert_noop!(
+				Messaging::remove(signed(ALICE), bounded_vec!(message_id)),
+				Error::<Test>::RequestPending
+			);
+			assert!(
+				Messages::<Test>::get(ALICE, message_id).is_some(),
+				"Message has been deleted when it should exist."
+			);
+		});
+	}
 
-                <Test as crate::messaging::Config>::Deposit::hold(&HoldReason::Messaging.into(), &ALICE, deposit).unwrap();
+	#[test]
+	fn ismp_message_is_removed_and_deposit_returned_when_status_is_timeout() {
+		new_test_ext().execute_with(|| {
+			let deposit: Balance = 100;
+			let message_id: MessageId = [0u8; 32];
+			let m = Message::Ismp {
+				commitment: H256::default(),
+				callback: None,
+				deposit,
+				status: MessageStatus::Timeout,
+			};
+			let alice_balance_pre_hold = Balances::free_balance(&ALICE);
 
-                let alice_balance_post_hold = Balances::free_balance(&ALICE);
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
 
-                Messages::<Test>::insert(&ALICE, message_id, &m);
-                assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
+			let alice_balance_post_hold = Balances::free_balance(&ALICE);
 
-                let alice_balance_post_remove = Balances::free_balance(&ALICE);
+			Messages::<Test>::insert(&ALICE, message_id, &m);
+			assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
 
-                assert_eq!(alice_balance_post_hold + deposit, alice_balance_pre_hold, "deposit amount is incorrect");
-                assert_eq!(alice_balance_post_remove, alice_balance_pre_hold, "alice balance has been mutated when it shouldnt have.");
-                assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
-            });
-        }
+			let alice_balance_post_remove = Balances::free_balance(&ALICE);
 
-        #[test]
-        fn ismp_message_is_removed_and_deposit_returned_when_status_is_err() {
-            new_test_ext().execute_with(|| {
-                let deposit: Balance = 100;
-                let message_id: MessageId =  [0u8; 32];
-                let m = Message::Ismp { commitment: H256::default(), callback: None, deposit, status: MessageStatus::Err(Error::<Test>::IsmpDispatchFailed.into()) };
-                let alice_balance_pre_hold = Balances::free_balance(&ALICE);
+			assert_eq!(
+				alice_balance_post_hold + deposit,
+				alice_balance_pre_hold,
+				"deposit amount is incorrect"
+			);
+			assert_eq!(
+				alice_balance_post_remove, alice_balance_pre_hold,
+				"alice balance has been mutated when it shouldnt have."
+			);
+			assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
+		});
+	}
 
-                <Test as crate::messaging::Config>::Deposit::hold(&HoldReason::Messaging.into(), &ALICE, deposit).unwrap();
+	#[test]
+	fn ismp_message_is_removed_and_deposit_returned_when_status_is_err() {
+		new_test_ext().execute_with(|| {
+			let deposit: Balance = 100;
+			let message_id: MessageId = [0u8; 32];
+			let m = Message::Ismp {
+				commitment: H256::default(),
+				callback: None,
+				deposit,
+				status: MessageStatus::Err(Error::<Test>::IsmpDispatchFailed.into()),
+			};
+			let alice_balance_pre_hold = Balances::free_balance(&ALICE);
 
-                let alice_balance_post_hold = Balances::free_balance(&ALICE);
+			<Test as crate::messaging::Config>::Deposit::hold(
+				&HoldReason::Messaging.into(),
+				&ALICE,
+				deposit,
+			)
+			.unwrap();
 
-                Messages::<Test>::insert(&ALICE, message_id, &m);
-                assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
+			let alice_balance_post_hold = Balances::free_balance(&ALICE);
 
-                let alice_balance_post_remove = Balances::free_balance(&ALICE);
+			Messages::<Test>::insert(&ALICE, message_id, &m);
+			assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
 
-                assert_eq!(alice_balance_post_hold + deposit, alice_balance_pre_hold, "deposit amount is incorrect");
-                assert_eq!(alice_balance_post_remove, alice_balance_pre_hold, "alice balance has been mutated when it shouldnt have.");
-                assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
-            });
-        }
+			let alice_balance_post_remove = Balances::free_balance(&ALICE);
 
-        #[test]
-        fn ismp_response_message_can_always_be_removed() {
-            new_test_ext().execute_with(|| {
-                
-            });
-        }
-        #[test]
-        fn xcm_queries_cannot_be_removed () {
-            new_test_ext().execute_with(|| {
-                let m_1_id = [0;32];
-                let m_1 = Message::XcmQuery { query_id: 0, callback: None, deposit: 0, status: MessageStatus::Ok };
-                let m_2_id = [1;32];
-                let m_2 = Message::XcmQuery { query_id: 1, callback: None, deposit: 0, status: MessageStatus::Timeout };
-                let m_3_id = [2;32];
-                let m_3 = Message::XcmQuery { query_id: 2, callback: None, deposit: 0, status: MessageStatus::Err(Error::<Test>::InvalidQuery.into())};
-                Messages::<Test>::insert(&ALICE, m_1_id, &m_1);
-                Messages::<Test>::insert(&ALICE, m_2_id, &m_2);
-                Messages::<Test>::insert(&ALICE, m_3_id, &m_3);
-                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(m_1_id)), Error::<Test>::RequestPending);
-                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(m_2_id)), Error::<Test>::RequestPending);
-                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(m_3_id)), Error::<Test>::RequestPending);
-                assert!(Messages::<Test>::get(ALICE, &m_1_id).is_some(), "Message has been deleted when it should still exist.");
-                assert!(Messages::<Test>::get(ALICE, &m_2_id).is_some(), "Message has been deleted when it should still exist.");
-                assert!(Messages::<Test>::get(ALICE, &m_3_id).is_some(), "Message has been deleted when it should still exist.");
-            });
-        }
+			assert_eq!(
+				alice_balance_post_hold + deposit,
+				alice_balance_pre_hold,
+				"deposit amount is incorrect"
+			);
+			assert_eq!(
+				alice_balance_post_remove, alice_balance_pre_hold,
+				"alice balance has been mutated when it shouldnt have."
+			);
+			assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
+		});
+	}
 
-        #[test]
-        fn xcm_response_messages_can_always_be_removed() {
-            new_test_ext().execute_with(|| {
+	#[test]
+	fn ismp_response_message_can_always_be_removed() {
+		new_test_ext().execute_with(|| {});
+	}
+	#[test]
+	fn xcm_queries_cannot_be_removed() {
+		new_test_ext().execute_with(|| {
+			let m_1_id = [0; 32];
+			let m_1 = Message::XcmQuery {
+				query_id: 0,
+				callback: None,
+				deposit: 0,
+				status: MessageStatus::Ok,
+			};
+			let m_2_id = [1; 32];
+			let m_2 = Message::XcmQuery {
+				query_id: 1,
+				callback: None,
+				deposit: 0,
+				status: MessageStatus::Timeout,
+			};
+			let m_3_id = [2; 32];
+			let m_3 = Message::XcmQuery {
+				query_id: 2,
+				callback: None,
+				deposit: 0,
+				status: MessageStatus::Err(Error::<Test>::InvalidQuery.into()),
+			};
+			Messages::<Test>::insert(&ALICE, m_1_id, &m_1);
+			Messages::<Test>::insert(&ALICE, m_2_id, &m_2);
+			Messages::<Test>::insert(&ALICE, m_3_id, &m_3);
+			assert_noop!(
+				Messaging::remove(signed(ALICE), bounded_vec!(m_1_id)),
+				Error::<Test>::RequestPending
+			);
+			assert_noop!(
+				Messaging::remove(signed(ALICE), bounded_vec!(m_2_id)),
+				Error::<Test>::RequestPending
+			);
+			assert_noop!(
+				Messaging::remove(signed(ALICE), bounded_vec!(m_3_id)),
+				Error::<Test>::RequestPending
+			);
+			assert!(
+				Messages::<Test>::get(ALICE, &m_1_id).is_some(),
+				"Message has been deleted when it should still exist."
+			);
+			assert!(
+				Messages::<Test>::get(ALICE, &m_2_id).is_some(),
+				"Message has been deleted when it should still exist."
+			);
+			assert!(
+				Messages::<Test>::get(ALICE, &m_3_id).is_some(),
+				"Message has been deleted when it should still exist."
+			);
+		});
+	}
 
-            });
-        }
+	#[test]
+	fn xcm_response_messages_can_always_be_removed() {
+		new_test_ext().execute_with(|| {});
+	}
 
-        #[test]
-        fn multiple_messages_remove_works() {
-            new_test_ext().execute_with(|| {
-                
-            });
-        }
+	#[test]
+	fn multiple_messages_remove_works() {
+		new_test_ext().execute_with(|| {});
+	}
 
-        #[test]
-        fn origin_can_only_remove_messages_related_to_itself() {
-            new_test_ext().execute_with(|| {
-    
-            });
-        }
-    }
-    
+	#[test]
+	fn origin_can_only_remove_messages_related_to_itself() {
+		new_test_ext().execute_with(|| {});
+	}
+}

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -104,21 +104,14 @@ use frame_support::testing_prelude::bounded_vec;
         #[test]
         fn xcm_response_messages_can_always_be_removed() {
             new_test_ext().execute_with(|| {
-    
+
             });
         }
 
         #[test]
         fn multiple_messages_remove_works() {
             new_test_ext().execute_with(|| {
-    
-            });
-        }
-
-        #[test]
-        fn multiple_messages_remove_ignores_erroneous_removes_and_continues() {
-            new_test_ext().execute_with(|| {
-    
+                
             });
         }
 

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -1,0 +1,73 @@
+use codec::Encode;
+use frame_support::{
+	assert_noop, assert_ok,
+	dispatch::WithPostDispatchInfo,
+	sp_runtime::{traits::Zero, BoundedVec, DispatchError::BadOrigin},
+	weights::Weight,
+};
+use pallet_nfts::{CollectionSetting, MintWitness, WeightInfo as NftsWeightInfoTrait};
+
+use crate::{
+	mock::*,
+	Read,
+    messaging::*,
+};
+use sp_core::H256;
+use frame_support::testing_prelude::bounded_vec;
+
+    mod remove {
+        use super::*;
+        
+
+        #[test]
+        fn ismp_message_is_noop_when_status_is_ok() {
+            new_test_ext().execute_with(|| {
+                let m = Message::Ismp { commitment: H256::default(), callback: None, deposit: 100, status: MessageStatus::Ok };
+                let message_id: MessageId =  [0u8; 32];
+                Messages::<Test>::insert(&ALICE, message_id, &m);
+                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)), Error::<Test>::RequestPending);
+            });
+        }
+
+        #[test]
+        fn ismp_message_is_removed_and_deposit_returned_when_status_is_timeout() {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+
+        #[test]
+        fn ismp_message_is_removed_and_deposit_returned_when_status_is_err() {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+
+        #[test]
+        fn ismp_response_message_can_always_be_removed() {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+        #[test]
+        fn xcm_queries_cannot_be_removed () {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+
+        #[test]
+        fn xcm_response_messages_can_always_be_removed() {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+
+        #[test]
+        fn multiple_messages_remove_works() {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+    }
+    

--- a/pallets/api/src/messaging/tests.rs
+++ b/pallets/api/src/messaging/tests.rs
@@ -17,8 +17,6 @@ use frame_support::testing_prelude::bounded_vec;
 
     mod remove {
         use super::*;
-        
-
         #[test]
         fn ismp_message_is_noop_when_status_is_ok() {
             new_test_ext().execute_with(|| {
@@ -26,33 +24,80 @@ use frame_support::testing_prelude::bounded_vec;
                 let message_id: MessageId =  [0u8; 32];
                 Messages::<Test>::insert(&ALICE, message_id, &m);
                 assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)), Error::<Test>::RequestPending);
+                assert!(Messages::<Test>::get(ALICE, message_id).is_some(), "Message has been deleted when it should exist.");
             });
         }
 
         #[test]
         fn ismp_message_is_removed_and_deposit_returned_when_status_is_timeout() {
             new_test_ext().execute_with(|| {
-    
+                let deposit: Balance = 100;
+                let message_id: MessageId =  [0u8; 32];
+                let m = Message::Ismp { commitment: H256::default(), callback: None, deposit, status: MessageStatus::Timeout };
+                let alice_balance_pre_hold = Balances::free_balance(&ALICE);
+
+                <Test as crate::messaging::Config>::Deposit::hold(&HoldReason::Messaging.into(), &ALICE, deposit).unwrap();
+
+                let alice_balance_post_hold = Balances::free_balance(&ALICE);
+
+                Messages::<Test>::insert(&ALICE, message_id, &m);
+                assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
+
+                let alice_balance_post_remove = Balances::free_balance(&ALICE);
+
+                assert_eq!(alice_balance_post_hold + deposit, alice_balance_pre_hold, "deposit amount is incorrect");
+                assert_eq!(alice_balance_post_remove, alice_balance_pre_hold, "alice balance has been mutated when it shouldnt have.");
+                assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
             });
         }
 
         #[test]
         fn ismp_message_is_removed_and_deposit_returned_when_status_is_err() {
             new_test_ext().execute_with(|| {
-    
+                let deposit: Balance = 100;
+                let message_id: MessageId =  [0u8; 32];
+                let m = Message::Ismp { commitment: H256::default(), callback: None, deposit, status: MessageStatus::Err(Error::<Test>::IsmpDispatchFailed.into()) };
+                let alice_balance_pre_hold = Balances::free_balance(&ALICE);
+
+                <Test as crate::messaging::Config>::Deposit::hold(&HoldReason::Messaging.into(), &ALICE, deposit).unwrap();
+
+                let alice_balance_post_hold = Balances::free_balance(&ALICE);
+
+                Messages::<Test>::insert(&ALICE, message_id, &m);
+                assert_ok!(Messaging::remove(signed(ALICE), bounded_vec!(message_id)));
+
+                let alice_balance_post_remove = Balances::free_balance(&ALICE);
+
+                assert_eq!(alice_balance_post_hold + deposit, alice_balance_pre_hold, "deposit amount is incorrect");
+                assert_eq!(alice_balance_post_remove, alice_balance_pre_hold, "alice balance has been mutated when it shouldnt have.");
+                assert!(Messages::<Test>::get(&ALICE, message_id).is_none());
             });
         }
 
         #[test]
         fn ismp_response_message_can_always_be_removed() {
             new_test_ext().execute_with(|| {
-    
+                
             });
         }
         #[test]
         fn xcm_queries_cannot_be_removed () {
             new_test_ext().execute_with(|| {
-    
+                let m_1_id = [0;32];
+                let m_1 = Message::XcmQuery { query_id: 0, callback: None, deposit: 0, status: MessageStatus::Ok };
+                let m_2_id = [1;32];
+                let m_2 = Message::XcmQuery { query_id: 1, callback: None, deposit: 0, status: MessageStatus::Timeout };
+                let m_3_id = [2;32];
+                let m_3 = Message::XcmQuery { query_id: 2, callback: None, deposit: 0, status: MessageStatus::Err(Error::<Test>::InvalidQuery.into())};
+                Messages::<Test>::insert(&ALICE, m_1_id, &m_1);
+                Messages::<Test>::insert(&ALICE, m_2_id, &m_2);
+                Messages::<Test>::insert(&ALICE, m_3_id, &m_3);
+                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(m_1_id)), Error::<Test>::RequestPending);
+                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(m_2_id)), Error::<Test>::RequestPending);
+                assert_noop!(Messaging::remove(signed(ALICE), bounded_vec!(m_3_id)), Error::<Test>::RequestPending);
+                assert!(Messages::<Test>::get(ALICE, &m_1_id).is_some(), "Message has been deleted when it should still exist.");
+                assert!(Messages::<Test>::get(ALICE, &m_2_id).is_some(), "Message has been deleted when it should still exist.");
+                assert!(Messages::<Test>::get(ALICE, &m_3_id).is_some(), "Message has been deleted when it should still exist.");
             });
         }
 
@@ -65,6 +110,20 @@ use frame_support::testing_prelude::bounded_vec;
 
         #[test]
         fn multiple_messages_remove_works() {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+
+        #[test]
+        fn multiple_messages_remove_ignores_erroneous_removes_and_continues() {
+            new_test_ext().execute_with(|| {
+    
+            });
+        }
+
+        #[test]
+        fn origin_can_only_remove_messages_related_to_itself() {
             new_test_ext().execute_with(|| {
     
             });

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -176,10 +176,11 @@ impl<T: Config> IsmpModule for Handler<T> {
 					else {
 						return Err(Error::Custom("message not found".into()))
 					};
-					*message = Some(super::super::Message::IsmpTimedOut {
-						deposit: *deposit,
-						commitment: *commitment,
-					});
+					todo!("Update message status to timed out");
+					// *message = Some(super::super::Message::IsmpTimedOut {
+					// 	deposit: *deposit,
+					// 	commitment: *commitment,
+					// });
 					Ok(())
 				})?;
 				Ok(())
@@ -226,7 +227,7 @@ fn process_response<T: Config>(
 	let (origin, id) =
 		IsmpRequests::<T>::get(commitment).ok_or(Error::Custom("request not found".into()))?;
 
-	let Some(super::super::Message::Ismp { commitment, callback, deposit }) =
+	let Some(super::super::Message::Ismp { commitment, callback, deposit, status}) =
 		Messages::<T>::get(&origin, &id)
 	else {
 		return Err(Error::Custom("message not found".into()).into())
@@ -235,6 +236,7 @@ fn process_response<T: Config>(
 	// Attempt callback with result if specified.
 	if let Some(callback) = callback {
 		// TODO: check response length
+		todo!("update message status on success or fail.");
 		if Pallet::<T>::call(origin.clone(), callback, id, &encode, deposit).is_ok() {
 			Pallet::<T>::deposit_event(event(origin, id));
 			return Ok(());
@@ -247,7 +249,7 @@ fn process_response<T: Config>(
 	Messages::<T>::insert(
 		&origin,
 		&id,
-		super::super::Message::IsmpResponse { commitment, deposit, response },
+		super::super::Message::IsmpResponse { commitment, deposit, response , status: todo!("take status from callback return value.")},
 	);
 	Pallet::<T>::deposit_event(event(origin, id));
 	Ok(())

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -238,7 +238,7 @@ fn process_response<T: Config>(
 		// TODO: check response length
 		todo!("update message status on success or fail.");
 		if Pallet::<T>::call(origin.clone(), callback, id, &encode, deposit).is_ok() {
-			Pallet::<T>::deposit_event(event(origin, id));
+				Pallet::<T>::deposit_event(event(origin, id));
 			return Ok(());
 		}
 	}

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -227,7 +227,7 @@ fn process_response<T: Config>(
 	let (origin, id) =
 		IsmpRequests::<T>::get(commitment).ok_or(Error::Custom("request not found".into()))?;
 
-	let Some(super::super::Message::Ismp { commitment, callback, deposit, status}) =
+	let Some(super::super::Message::Ismp { commitment, callback, deposit, status }) =
 		Messages::<T>::get(&origin, &id)
 	else {
 		return Err(Error::Custom("message not found".into()).into())
@@ -238,7 +238,7 @@ fn process_response<T: Config>(
 		// TODO: check response length
 		todo!("update message status on success or fail.");
 		if Pallet::<T>::call(origin.clone(), callback, id, &encode, deposit).is_ok() {
-				Pallet::<T>::deposit_event(event(origin, id));
+			Pallet::<T>::deposit_event(event(origin, id));
 			return Ok(());
 		}
 	}
@@ -249,7 +249,12 @@ fn process_response<T: Config>(
 	Messages::<T>::insert(
 		&origin,
 		&id,
-		super::super::Message::IsmpResponse { commitment, deposit, response , status: todo!("take status from callback return value.")},
+		super::super::Message::IsmpResponse {
+			commitment,
+			deposit,
+			response,
+			status: todo!("take status from callback return value."),
+		},
 	);
 	Pallet::<T>::deposit_event(event(origin, id));
 	Ok(())

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -22,11 +22,11 @@ use ismp::{
 use pallet_ismp::weights::IsmpModuleWeight;
 use scale_info::TypeInfo;
 use sp_core::{keccak_256, H256};
-use sp_runtime::{BoundedVec, SaturatedConversion, Saturating};
+use sp_runtime::{BoundedVec, Saturating};
 
 use crate::messaging::{
 	pallet::{Config, Event, IsmpRequests, Messages, Pallet},
-	AccountIdOf, BalanceOf, MessageId, Vec,
+	AccountIdOf, MessageId, Vec,
 };
 
 pub const ID: [u8; 3] = *b"pop";
@@ -163,7 +163,6 @@ impl<T: Config> IsmpModule for Handler<T> {
 					// 	deposit: *deposit,
 					// 	commitment: *commitment,
 					// });
-					Ok(())
 				})?;
 				Ok(())
 			},

--- a/pallets/api/src/messaging/transports/ismp.rs
+++ b/pallets/api/src/messaging/transports/ismp.rs
@@ -49,7 +49,9 @@ impl<T: Config> From<Message<T>> for DispatchRequest {
 	}
 }
 
-#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo, MaxEncodedLen,
+)]
 #[scale_info(skip_type_params(T))]
 pub struct Get<T: Config> {
 	// TODO: Option<u32> to support relay?
@@ -79,7 +81,9 @@ impl<T: Config> From<Get<T>> for DispatchRequest {
 	}
 }
 
-#[derive(Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Encode, EqNoBound, CloneNoBound, DebugNoBound, Decode, PartialEqNoBound, TypeInfo, MaxEncodedLen,
+)]
 #[scale_info(skip_type_params(T))]
 pub struct Post<T: Config> {
 	// TODO: Option<u32> to support relay?

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -1,22 +1,22 @@
 use codec::{Decode, Encode};
 use frame_support::{
-	derive_impl, parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU64, Everything},
+	derive_impl,
+	pallet_prelude::EnsureOrigin,
+	parameter_types,
+	traits::{AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU64, Everything, OriginTrait},
 };
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{pallet_prelude::BlockNumberFor, EnsureRoot, EnsureSigned};
 use pallet_nfts::PalletFeatures;
+use pallet_xcm::Origin;
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Lazy, Verify},
 	BuildStorage,
 };
-
-use crate::messaging::{CallbackExecutor, NotifyQueryHandler, Call};
 use xcm::latest::Location;
-use frame_system::{pallet_prelude::BlockNumberFor};
-use frame_support::{pallet_prelude::EnsureOrigin, traits::OriginTrait};
-use pallet_xcm::Origin;
+
+use crate::messaging::{Call, CallbackExecutor, NotifyQueryHandler};
 
 pub(crate) const ALICE: AccountId = 1;
 pub(crate) const BOB: AccountId = 2;
@@ -210,7 +210,11 @@ impl crate::nonfungibles::Config for Test {
 
 pub struct MockCallbackExecutor<T>(T);
 impl<T: crate::messaging::Config> CallbackExecutor<T> for MockCallbackExecutor<T> {
-	fn execute(account: <T as frame_system::Config>::AccountId, data: Vec<u8>, weight: sp_runtime::Weight) -> frame_support::dispatch::DispatchResultWithPostInfo {
+	fn execute(
+		account: <T as frame_system::Config>::AccountId,
+		data: Vec<u8>,
+		weight: sp_runtime::Weight,
+	) -> frame_support::dispatch::DispatchResultWithPostInfo {
 		Ok(().into())
 	}
 
@@ -259,20 +263,20 @@ pub struct MockIsmpDispatcher;
 impl ismp::dispatcher::IsmpDispatcher for MockIsmpDispatcher {
 	type Account = AccountId;
 	type Balance = Balance;
-	
-	fn dispatch_request(
-			&self,
-			request: ismp::dispatcher::DispatchRequest,
-			fee: ismp::dispatcher::FeeMetadata<Self::Account, Self::Balance>,
-		) -> Result<H256, anyhow::Error> {
 
-			Ok(Default::default())
+	fn dispatch_request(
+		&self,
+		request: ismp::dispatcher::DispatchRequest,
+		fee: ismp::dispatcher::FeeMetadata<Self::Account, Self::Balance>,
+	) -> Result<H256, anyhow::Error> {
+		Ok(Default::default())
 	}
+
 	fn dispatch_response(
-			&self,
-			response: ismp::router::PostResponse,
-			fee: ismp::dispatcher::FeeMetadata<Self::Account, Self::Balance>,
-		) -> Result<H256, anyhow::Error> {
+		&self,
+		response: ismp::router::PostResponse,
+		fee: ismp::dispatcher::FeeMetadata<Self::Account, Self::Balance>,
+	) -> Result<H256, anyhow::Error> {
 		Ok(Default::default())
 	}
 }

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -240,10 +240,10 @@ impl<T: crate::messaging::Config> NotifyQueryHandler<T> for MockNotifyQuery<T> {
 }
 
 impl crate::messaging::Config for Test {
-	type ByteFee = TransactionByteFee;
+	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = MockCallbackExecutor<Test>;
 	type Deposit = Balances;
-	type IsmpByteFee = ();
+	type OffChainByteFee = ();
 	type IsmpDispatcher = MockIsmpDispatcher;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;

--- a/pallets/api/src/mock.rs
+++ b/pallets/api/src/mock.rs
@@ -240,10 +240,8 @@ impl<T: crate::messaging::Config> NotifyQueryHandler<T> for MockNotifyQuery<T> {
 }
 
 impl crate::messaging::Config for Test {
-	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = MockCallbackExecutor<Test>;
 	type Deposit = Balances;
-	type OffChainByteFee = ();
 	type IsmpDispatcher = MockIsmpDispatcher;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;
@@ -251,6 +249,8 @@ impl crate::messaging::Config for Test {
 	type MaxKeys = ConstU32<10>;
 	type MaxRemovals = ConstU32<1024>;
 	type MaxResponseLen = ConstU32<1024>;
+	type OffChainByteFee = ();
+	type OnChainByteFee = TransactionByteFee;
 	type OriginConverter = ();
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;

--- a/pallets/api/src/nonfungibles/benchmarking.rs
+++ b/pallets/api/src/nonfungibles/benchmarking.rs
@@ -1,8 +1,12 @@
 //! Benchmarking setup for pallet_api::nonfungibles
 
 use frame_benchmarking::{account, v2::*};
-use frame_support::BoundedVec;
+use frame_support::{
+	BoundedVec,
+	traits::Currency,
+};
 use sp_runtime::traits::Zero;
+
 
 use super::{
 	AttributeNamespace, CollectionIdOf, Config, Inspect, ItemIdOf, NftsInstanceOf, Pallet, Read,

--- a/pallets/api/src/nonfungibles/benchmarking.rs
+++ b/pallets/api/src/nonfungibles/benchmarking.rs
@@ -1,12 +1,8 @@
 //! Benchmarking setup for pallet_api::nonfungibles
 
 use frame_benchmarking::{account, v2::*};
-use frame_support::{
-	BoundedVec,
-	traits::Currency,
-};
+use frame_support::{traits::Currency, BoundedVec};
 use sp_runtime::traits::Zero;
-
 
 use super::{
 	AttributeNamespace, CollectionIdOf, Config, Inspect, ItemIdOf, NftsInstanceOf, Pallet, Read,

--- a/pop-api/Cargo.toml
+++ b/pop-api/Cargo.toml
@@ -40,3 +40,4 @@ std = [
 	"pop-primitives/std",
 	"sp-io/std",
 ]
+messaging = [	]

--- a/pop-api/src/v0/mod.rs
+++ b/pop-api/src/v0/mod.rs
@@ -8,12 +8,12 @@ use crate::{
 /// APIs for fungible tokens.
 #[cfg(feature = "fungibles")]
 pub mod fungibles;
-/// APIs for non-fungible tokens.
-#[cfg(feature = "nonfungibles")]
-pub mod nonfungibles;
 /// APIs for messaging.
 #[cfg(feature = "messaging")]
 pub mod messaging;
+/// APIs for non-fungible tokens.
+#[cfg(feature = "nonfungibles")]
+pub mod nonfungibles;
 
 pub(crate) const V0: u8 = 0;
 

--- a/pop-api/src/v0/mod.rs
+++ b/pop-api/src/v0/mod.rs
@@ -11,6 +11,9 @@ pub mod fungibles;
 /// APIs for non-fungible tokens.
 #[cfg(feature = "nonfungibles")]
 pub mod nonfungibles;
+/// APIs for messaging.
+#[cfg(feature = "messaging")]
+pub mod messaging;
 
 pub(crate) const V0: u8 = 0;
 

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -112,12 +112,8 @@ impl nonfungibles::Config for Runtime {
 }
 
 impl messaging::Config for Runtime {
-	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = CallbackExecutor;
 	type Deposit = Balances;
-	// TODO: ISMP state written to offchain indexing, require some protection but perhaps not as
-	// much as onchain cost.
-	type OffChainByteFee = 	();
 	type IsmpDispatcher = Ismp;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;
@@ -127,6 +123,10 @@ impl messaging::Config for Runtime {
 	type MaxRemovals = ConstU32<1024>;
 	// TODO: ensure within the contract buffer bounds
 	type MaxResponseLen = ConstU32<1024>;
+	// TODO: ISMP state written to offchain indexing, require some protection but perhaps not as
+	// much as onchain cost.
+	type OffChainByteFee = ();
+	type OnChainByteFee = TransactionByteFee;
 	type OriginConverter = LocalOriginToLocation;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -112,12 +112,12 @@ impl nonfungibles::Config for Runtime {
 }
 
 impl messaging::Config for Runtime {
-	type ByteFee = TransactionByteFee;
+	type OnChainByteFee = TransactionByteFee;
 	type CallbackExecutor = CallbackExecutor;
 	type Deposit = Balances;
 	// TODO: ISMP state written to offchain indexing, require some protection but perhaps not as
 	// much as onchain cost.
-	type IsmpByteFee = ();
+	type OffChainByteFee = 	();
 	type IsmpDispatcher = Ismp;
 	type MaxContextLen = ConstU32<64>;
 	type MaxDataLen = ConstU32<1024>;

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -3,21 +3,27 @@ use core::marker::PhantomData;
 
 use codec::Decode;
 use cumulus_primitives_core::Weight;
-use frame_support::{traits::Contains, pallet_prelude::*, dispatch::{PostDispatchInfo, DispatchErrorWithPostInfo}};
+use frame_support::{
+	dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo},
+	pallet_prelude::*,
+	traits::Contains,
+};
 pub(crate) use pallet_api::Extension;
 use pallet_api::{extension::*, Read};
+use pallet_revive::{AddressMapper, CollectEvents, DebugInfo};
+use pallet_xcm::Origin;
 use sp_core::ConstU8;
 use sp_runtime::DispatchError;
 use versioning::*;
-
-use pallet_revive::{DebugInfo, CollectEvents, AddressMapper};
 use xcm::latest::Location;
-use pallet_xcm::Origin;
+
 use crate::{
-	config::assets::{TrustBackedAssetsInstance, TrustBackedNftsInstance},
-	fungibles, nonfungibles, Runtime, RuntimeCall, RuntimeEvent, messaging,
-	TransactionByteFee, Balances, Ismp, ConstU32, RuntimeHoldReason, config::xcm::LocalOriginToLocation,
-	AccountId, Revive, RuntimeOrigin, BlockNumber 
+	config::{
+		assets::{TrustBackedAssetsInstance, TrustBackedNftsInstance},
+		xcm::LocalOriginToLocation,
+	},
+	fungibles, messaging, nonfungibles, AccountId, Balances, BlockNumber, ConstU32, Ismp, Revive,
+	Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin, TransactionByteFee,
 };
 
 mod versioning;
@@ -44,7 +50,6 @@ pub enum RuntimeRead {
 	/// Messaging read queries.
 	#[codec(index = 152)]
 	Messaging(messaging::Read<Runtime>),
-	
 }
 
 impl Readable for RuntimeRead {
@@ -58,7 +63,6 @@ impl Readable for RuntimeRead {
 			RuntimeRead::Fungibles(key) => fungibles::Pallet::weight(key),
 			RuntimeRead::NonFungibles(key) => nonfungibles::Pallet::weight(key),
 			RuntimeRead::Messaging(key) => messaging::Pallet::weight(key),
-
 		}
 	}
 
@@ -130,7 +134,6 @@ impl messaging::Config for Runtime {
 	type XcmResponseOrigin = EnsureResponse;
 }
 
-
 pub struct EnsureResponse;
 impl<O: Into<Result<Origin, O>> + From<Origin>> EnsureOrigin<O> for EnsureResponse {
 	type Success = Location;
@@ -147,7 +150,6 @@ impl<O: Into<Result<Origin, O>> + From<Origin>> EnsureOrigin<O> for EnsureRespon
 		todo!()
 	}
 }
-
 
 pub struct CallbackExecutor;
 impl messaging::CallbackExecutor<Runtime> for CallbackExecutor {
@@ -200,7 +202,6 @@ impl messaging::CallbackExecutor<Runtime> for CallbackExecutor {
 		<Runtime as pallet_revive::Config>::WeightInfo::call()
 	}
 }
-
 
 // TODO!( default implementation where T: PolkadotXcm::Config
 pub struct QueryHandler;

--- a/runtime/devnet/src/config/api/mod.rs
+++ b/runtime/devnet/src/config/api/mod.rs
@@ -127,9 +127,26 @@ impl messaging::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type Xcm = QueryHandler;
-	type XcmResponseOrigin = pallet_xcm::EnsureResponse<()>;
+	type XcmResponseOrigin = EnsureResponse;
 }
 
+
+pub struct EnsureResponse;
+impl<O: Into<Result<Origin, O>> + From<Origin>> EnsureOrigin<O> for EnsureResponse {
+	type Success = Location;
+
+	fn try_origin(o: O) -> Result<Self::Success, O> {
+		o.into().and_then(|o| match o {
+			Origin::Response(location) => Ok(location),
+			r => Err(O::from(r)),
+		})
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<O, ()> {
+		todo!()
+	}
+}
 
 
 pub struct CallbackExecutor;

--- a/runtime/devnet/src/config/ismp.rs
+++ b/runtime/devnet/src/config/ismp.rs
@@ -41,7 +41,7 @@ impl Get<StateMachine> for HostStateMachine {
 		StateMachine::Polkadot(ParachainInfo::get().into())
 	}
 }
-  
+
 #[derive(Default)]
 pub struct Router;
 impl IsmpRouter for Router {

--- a/runtime/devnet/src/config/mod.rs
+++ b/runtime/devnet/src/config/mod.rs
@@ -5,5 +5,5 @@ mod contracts;
 mod ismp;
 mod proxy;
 // Public due to integration tests crate.
-pub mod xcm;
 mod revive;
+pub mod xcm;

--- a/runtime/devnet/src/config/revive.rs
+++ b/runtime/devnet/src/config/revive.rs
@@ -22,7 +22,7 @@ impl pallet_revive::Config for Runtime {
 	type CallFilter = Nothing;
 	type ChainExtension = ();
 	// todo!("Call with peter, currently we are only implementing the extension for
- // pallet-contracts");
+	// pallet-contracts");
 	type ChainId = ConstU64<4001>;
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Currency = Balances;

--- a/runtime/devnet/src/config/revive.rs
+++ b/runtime/devnet/src/config/revive.rs
@@ -20,7 +20,9 @@ parameter_types! {
 impl pallet_revive::Config for Runtime {
 	type AddressMapper = pallet_revive::AccountId32Mapper<Runtime>;
 	type CallFilter = Nothing;
-	type ChainExtension = (); //todo!("Call with peter, currently we are only implementing the extension for pallet-contracts");
+	type ChainExtension = ();
+	// todo!("Call with peter, currently we are only implementing the extension for
+ // pallet-contracts");
 	type ChainId = ConstU64<4001>;
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Currency = Balances;
@@ -28,6 +30,7 @@ impl pallet_revive::Config for Runtime {
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
+	type NativeToEthRatio = ConstU32<1_000_000>;
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
@@ -39,10 +42,9 @@ impl pallet_revive::Config for Runtime {
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type Xcm = pallet_xcm::Pallet<Self>;
-	type NativeToEthRatio = ConstU32<1_000_000>;
 }
 
 // Mock implementation running for messaging.
-// remove extrinsic tests / benchmarking.	
+// remove extrinsic tests / benchmarking.
 // xcm spike
-// ismp spike 
+// ismp spike

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -43,7 +43,7 @@ use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot,
 };
-use pallet_api::{fungibles, nonfungibles, messaging};
+use pallet_api::{fungibles, messaging, nonfungibles};
 use pallet_balances::Call as BalancesCall;
 use pallet_ismp::offchain::{Leaf, Proof, ProofKeys};
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -677,6 +677,7 @@ mod benches {
 		[pallet_collator_selection, CollatorSelection]
 		[cumulus_pallet_parachain_system, ParachainSystem]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
+		[messaging, Messaging]
 	);
 }
 


### PR DESCRIPTION
This goes over most of the General section of the messaging pallet's tasks. 

## Losing ones deposit
Previousy, in the extrinsics that take a message deposit, there was a possibility that the extrinsic would error before the message is stored and therefore when one tried to removed the message, it did not exist and therefore, the deposit could not be claimed. This has been fixed by moving much of the validation code before taking the deposit and then handling the fallible code after taking deposit more appropriately.

## Remove extrinsic
Notably the `remove` extrinsic has had a makeover so that it can be more comfortably unit tested.
I have moved much of the logic into the impl of `Message`, encapsulating the logic like this allowed me to cut down the complexity of the tests and the code.
Many tests have been written and cover all bases as far as im concerned.

The extrinsic has also been made transactional this is because we deposit an event at the end of the extrinsic that emits the messages removed, The previous implementation would remove messages without emitting an event which will be a pain for app devs . We could build it so it ignores erroneous messages and emits only the ones that pass but i thought this was a quick fix and i have lots to do thats of higher priority.

## MessageStatus
The `MessageStatus` has been introduced and ive moved away from combination of message status and message type.

Previously a message would be of type `IsmpTimedOut` now it is an `IsmpMessage` with the status of `TimedOut`.
This was done to differentiate between what a message is and what status it is in. I think this will allow more flexibility for messages in the future.  The downside is that one must handle all message statuses for a message and the previous version uses Rust's type system to enforce a messages status. This is the change im least confident about.

## Storage Deposits
Previously the deposit implementations were scattered around the codebase and there was a trait called `CalculateDeposits`. Following this code was more difficult than it had to be. I have made `deposits.rs` to contain all the deposit calculation code, and used a blanket implementation instead of the specific impls of the `CalculateDeposits`. This has improved readability nicely.
The `IsmpByteFee` is intended for Offchain storage costs hence it has been replaced with OffchainByteFee.
ByteFee has subsequently been changed to OnChainByteFee.

## Other
`CallbackT` has been renamed to CallbackExecutor for better semantics.
MessageId has been changed to a [u8; 32] from an unsigned integer. 



[sc-3066]